### PR TITLE
Fixed overflow texts with ellipsis string headers

### DIFF
--- a/static/jscn/contlist.js
+++ b/static/jscn/contlist.js
@@ -92,7 +92,7 @@ async function populate_container_list () {
                             <div class="card card-widget shadow-sm">
                                 <div class="info-box mb-0 mt-0">
                                     <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
-                                    <div class="info-box-content">
+                                    <div class="info-box-content ellipsis">
                                         <span class="info-box-text monotext text-olive">${data[indx]["id"].substring(0,10)}</span>
                                         <span class="info-box-number h2 mb-0 condqant font-weight-normal text-olive">${data[indx]["name"]}</span>
                                     </div>

--- a/static/jscn/dashbard.js
+++ b/static/jscn/dashbard.js
@@ -37,7 +37,7 @@ async function populate_container_list() {
                         <li class="nav-item">
                             <a href="/contdata/${data[indx]["id"]}" class="nav-link">
                                 <span class="font-weight-bold">
-                                    ${data[indx]["name"]}
+                                    ${data[indx]["name"].substring(0, 30)}
                                 </span>
                                 <span class="float-right monotext text-olive text-uppercase">
                                     ${indx}
@@ -72,7 +72,7 @@ async function populate_image_list() {
                         <li class="nav-item">
                             <a href="/imejdata/${data[indx]["id"]}" class="nav-link">
                                 <span class="font-weight-bold">
-                                    ${data[indx]["name"]}
+                                    ${data[indx]["name"].substring(0, 30)}
                                 </span>
                                 <span class="float-right monotext text-olive text-uppercase">
                                     ${indx.substr(7,10)}
@@ -107,7 +107,7 @@ async function populate_network_list() {
                         <li class="nav-item">
                             <a href="/ntwkdata/${data[indx]["id"]}" class="nav-link">
                                 <span class="font-weight-bold">
-                                    ${data[indx]["name"]}
+                                    ${data[indx]["name"].substring(0, 30)}
                                 </span>
                                 <span class="float-right monotext text-olive text-uppercase">
                                     ${indx}
@@ -142,7 +142,7 @@ async function populate_volume_list() {
                         <li class="nav-item">
                             <a href="/volmdata/${data[indx]["id"]}" class="nav-link">
                                 <span class="font-weight-bold">
-                                    ${data[indx]["name"]}
+                                    ${data[indx]["name"].substring(0, 30)}
                                 </span>
                                 <span class="float-right monotext text-olive text-uppercase">
                                     ${indx}

--- a/static/jscn/dockstat.js
+++ b/static/jscn/dockstat.js
@@ -306,8 +306,8 @@ async function populate_version_section() {
                             <div class="card-header bg-olive pl-2">
                                 <h3 class="card-title font-weight-bold">${data["Components"][indx]["Name"]}&nbsp;${data["Components"][indx]["Version"]}</h3>
                             </div>
-                            <div class="card-body table-responsive p-0">
-                                <table class="table table-sm table-hover text-nowrap">
+                            <div class="card-body p-0">
+                                <table class="table table-sm table-hover">
                                     <thead>
                                         <tr>
                                             <th class="pl-2" style="width: 25%;">Attributes</th>

--- a/static/jscn/imejlist.js
+++ b/static/jscn/imejlist.js
@@ -63,7 +63,7 @@ async function populate_image_list () {
                             <div class="card card-widget shadow-sm">
                                 <div class="info-box mb-0 mt-0">
                                     <span class="info-box-icon bg-olive"><i class="fas fa-sd-card"></i></span>
-                                    <div class="info-box-content">
+                                    <div class="info-box-content ellipsis">
                                         <span class="info-box-text monotext text-olive">${data[indx]["id"].substring(7,17)}</span>
                                         <span class="info-box-number h2 mb-0 condqant font-weight-normal text-olive">${data[indx]["name"]}</span>
                                     </div>

--- a/static/jscn/ntwklist.js
+++ b/static/jscn/ntwklist.js
@@ -62,7 +62,7 @@ async function populate_network_list () {
                         <div class="col-md-6 col-sm-12 col-12">
                             <a class="info-box mb-1 mt-1" href="/ntwkdata/${data[indx]["id"]}">
                                 <span class="info-box-icon bg-olive"><i class="fas fa-network-wired"></i></span>
-                                <div class="info-box-content">
+                                <div class="info-box-content ellipsis">
                                     <span class="info-box-text monotext">${data[indx]["id"].substring(0,10)}</span>
                                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">${data[indx]["name"]}</span>
                                 </div>

--- a/static/jscn/volmlist.js
+++ b/static/jscn/volmlist.js
@@ -62,7 +62,7 @@ async function populate_volume_list () {
                         <div class="col-md-6 col-sm-12 col-12">
                             <a class="info-box mb-1 mt-1" href="/volmdata/${data[indx]["id"]}">
                                 <span class="info-box-icon bg-olive"><i class="fas fa-database"></i></span>
-                                <div class="info-box-content">
+                                <div class="info-box-content ellipsis">
                                     <span class="info-box-text monotext">${data[indx]["id"].substring(0,10)}</span>
                                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">${data[indx]["name"]}</span>
                                 </div>

--- a/templates/contstat.html
+++ b/templates/contstat.html
@@ -46,7 +46,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-microchip"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">CPU usage</span>
                 </div>
@@ -151,7 +151,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-microchip"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Pre-CPU usage</span>
                 </div>
@@ -247,7 +247,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-memory"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Memory</span>
                 </div>
@@ -308,7 +308,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-network-wired"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Networks</span>
                 </div>

--- a/templates/dashbard.html
+++ b/templates/dashbard.html
@@ -43,7 +43,7 @@
         <div class="col-md-6 col-sm-6 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Containers</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal" id="contnumb">0</span>
                 </div>
@@ -58,7 +58,7 @@
         <div class="col-md-6 col-sm-6 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-sd-card"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Images</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal" id="imejnumb">0</span>
                 </div>
@@ -73,7 +73,7 @@
         <div class="col-md-6 col-sm-6 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-database"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Volumes</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal" id="volmnumb">0</span>
                 </div>
@@ -88,7 +88,7 @@
         <div class="col-md-6 col-sm-6 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-network-wired"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Networks</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal" id="ntwknumb">0</span>
                 </div>

--- a/templates/dockstat.html
+++ b/templates/dockstat.html
@@ -41,16 +41,16 @@
 {% block contwrap %}
     <div class="info-box">
         <span class="info-box-icon bg-olive"><i class="fas fa-fingerprint"></i></span>
-        <div class="info-box-content">
+        <div class="info-box-content ellipsis">
             <span class="info-box-text">Server ID</span>
-            <span class="info-box-number h2 mb-0 condqant font-weight-normal nogetout" id="speciden">UNAVAILABLE</span>
+            <span class="info-box-number h2 mb-0 condqant font-weight-normal" id="speciden">UNAVAILABLE</span>
         </div>
     </div>
     <div class="row">
         <div class="col-md-6 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-info-circle"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Docker</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Information</span>
                 </div>
@@ -126,7 +126,7 @@
         <div class="col-md-6 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-code-branch"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Docker</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Version</span>
                 </div>

--- a/templates/frameset.html
+++ b/templates/frameset.html
@@ -27,6 +27,12 @@
             -webkit-hyphens: none;
             hyphens: auto;
         }
+        .ellipsis {
+            white-space: nowrap;
+            overflow: hidden;
+            display: block;
+            text-overflow: ellipsis;
+        }
     </style>
     <body class="hold-transition sidebar-mini text-sm" onload="{% block onldscpt %}{% endblock %}" style="">
         <div class="wrapper">

--- a/templates/ntwkinfo.html
+++ b/templates/ntwkinfo.html
@@ -44,7 +44,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-info-circle"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Information</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Preliminary</span>
                 </div>
@@ -110,7 +110,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Active</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Containers</span>
                 </div>
@@ -123,7 +123,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-wrench"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Additional</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Options</span>
                 </div>

--- a/templates/proclist.html
+++ b/templates/proclist.html
@@ -44,7 +44,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-hashtag"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Active</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Processes</span>
                 </div>

--- a/templates/systdata.html
+++ b/templates/systdata.html
@@ -43,7 +43,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-info-circle"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Information</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Preliminary</span>
                 </div>
@@ -99,7 +99,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-memory"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Memory</span>
                 </div>
@@ -206,7 +206,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-microchip"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">CPU</span>
                 </div>
@@ -283,7 +283,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-compact-disc"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Storage</span>
                 </div>
@@ -330,7 +330,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-compact-disc"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Networks</span>
                 </div>
@@ -394,7 +394,7 @@
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-compact-disc"></i></span>
-                <div class="info-box-content">
+                <div class="info-box-content ellipsis">
                     <span class="info-box-text">Statistics</span>
                     <span class="info-box-number h2 mb-0 condqant font-weight-normal">Sensors</span>
                 </div>


### PR DESCRIPTION
Limited substring length to 25 chars on dashboard listing.

Fixes #33 and #34.

Screenshots.

![image](https://user-images.githubusercontent.com/49605954/109192386-2482ac80-77bd-11eb-9cad-87032954a901.png)

![image](https://user-images.githubusercontent.com/49605954/109192429-3401f580-77bd-11eb-9ce4-4082d54cda78.png)

![image](https://user-images.githubusercontent.com/49605954/109192528-572ca500-77bd-11eb-8b7c-21ca58638a77.png)
