### PR TITLE
Version bump from release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="15%" src="https://raw.githubusercontent.com/t0xic0der/supervisor-frontend-service/container-monitoring/pictures/mainicon.svg" />
+  <img width="15%" src="https://raw.githubusercontent.com/t0xic0der/supervisor-frontend-service/8ef30b5bcdc17496cfafb438837e517657ce8c27/pictures/mainicon.svg" />
 </p>
 
 <h1 align="center">SuperVisor</h1>

--- a/static/css3/adminlte.css
+++ b/static/css3/adminlte.css
@@ -1,13 +1,13 @@
 /*!
- *   AdminLTE v3.1.0-rc
+ *   AdminLTE v3.1.0
  *   Author: Colorlib
  *   Website: AdminLTE.io <https://adminlte.io>
  *   License: Open source - MIT <https://opensource.org/licenses/MIT>
  */
 /*!
- * Bootstrap v4.5.3 (https://getbootstrap.com/)
- * Copyright 2011-2020 The Bootstrap Authors
- * Copyright 2011-2020 Twitter, Inc.
+ * Bootstrap v4.6.0 (https://getbootstrap.com/)
+ * Copyright 2011-2021 The Bootstrap Authors
+ * Copyright 2011-2021 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 :root {
@@ -234,9 +234,8 @@ button {
   border-radius: 0;
 }
 
-button:focus {
-  outline: 1px dotted;
-  outline: 5px auto -webkit-focus-ring-color;
+button:focus:not(:focus-visible) {
+  outline: 0;
 }
 
 input,
@@ -589,8 +588,10 @@ pre code {
 }
 
 .row {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   margin-right: -7.5px;
@@ -621,50 +622,59 @@ pre code {
 }
 
 .col {
+  -webkit-flex-basis: 0;
   -ms-flex-preferred-size: 0;
   flex-basis: 0;
+  -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
   max-width: 100%;
 }
 
 .row-cols-1 > * {
+  -webkit-flex: 0 0 100%;
   -ms-flex: 0 0 100%;
   flex: 0 0 100%;
   max-width: 100%;
 }
 
 .row-cols-2 > * {
+  -webkit-flex: 0 0 50%;
   -ms-flex: 0 0 50%;
   flex: 0 0 50%;
   max-width: 50%;
 }
 
 .row-cols-3 > * {
+  -webkit-flex: 0 0 33.333333%;
   -ms-flex: 0 0 33.333333%;
   flex: 0 0 33.333333%;
   max-width: 33.333333%;
 }
 
 .row-cols-4 > * {
+  -webkit-flex: 0 0 25%;
   -ms-flex: 0 0 25%;
   flex: 0 0 25%;
   max-width: 25%;
 }
 
 .row-cols-5 > * {
+  -webkit-flex: 0 0 20%;
   -ms-flex: 0 0 20%;
   flex: 0 0 20%;
   max-width: 20%;
 }
 
 .row-cols-6 > * {
+  -webkit-flex: 0 0 16.666667%;
   -ms-flex: 0 0 16.666667%;
   flex: 0 0 16.666667%;
   max-width: 16.666667%;
 }
 
 .col-auto {
+  -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   width: auto;
@@ -672,148 +682,175 @@ pre code {
 }
 
 .col-1 {
+  -webkit-flex: 0 0 8.333333%;
   -ms-flex: 0 0 8.333333%;
   flex: 0 0 8.333333%;
   max-width: 8.333333%;
 }
 
 .col-2 {
+  -webkit-flex: 0 0 16.666667%;
   -ms-flex: 0 0 16.666667%;
   flex: 0 0 16.666667%;
   max-width: 16.666667%;
 }
 
 .col-3 {
+  -webkit-flex: 0 0 25%;
   -ms-flex: 0 0 25%;
   flex: 0 0 25%;
   max-width: 25%;
 }
 
 .col-4 {
+  -webkit-flex: 0 0 33.333333%;
   -ms-flex: 0 0 33.333333%;
   flex: 0 0 33.333333%;
   max-width: 33.333333%;
 }
 
 .col-5 {
+  -webkit-flex: 0 0 41.666667%;
   -ms-flex: 0 0 41.666667%;
   flex: 0 0 41.666667%;
   max-width: 41.666667%;
 }
 
 .col-6 {
+  -webkit-flex: 0 0 50%;
   -ms-flex: 0 0 50%;
   flex: 0 0 50%;
   max-width: 50%;
 }
 
 .col-7 {
+  -webkit-flex: 0 0 58.333333%;
   -ms-flex: 0 0 58.333333%;
   flex: 0 0 58.333333%;
   max-width: 58.333333%;
 }
 
 .col-8 {
+  -webkit-flex: 0 0 66.666667%;
   -ms-flex: 0 0 66.666667%;
   flex: 0 0 66.666667%;
   max-width: 66.666667%;
 }
 
 .col-9 {
+  -webkit-flex: 0 0 75%;
   -ms-flex: 0 0 75%;
   flex: 0 0 75%;
   max-width: 75%;
 }
 
 .col-10 {
+  -webkit-flex: 0 0 83.333333%;
   -ms-flex: 0 0 83.333333%;
   flex: 0 0 83.333333%;
   max-width: 83.333333%;
 }
 
 .col-11 {
+  -webkit-flex: 0 0 91.666667%;
   -ms-flex: 0 0 91.666667%;
   flex: 0 0 91.666667%;
   max-width: 91.666667%;
 }
 
 .col-12 {
+  -webkit-flex: 0 0 100%;
   -ms-flex: 0 0 100%;
   flex: 0 0 100%;
   max-width: 100%;
 }
 
 .order-first {
+  -webkit-order: -1;
   -ms-flex-order: -1;
   order: -1;
 }
 
 .order-last {
+  -webkit-order: 13;
   -ms-flex-order: 13;
   order: 13;
 }
 
 .order-0 {
+  -webkit-order: 0;
   -ms-flex-order: 0;
   order: 0;
 }
 
 .order-1 {
+  -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
 }
 
 .order-2 {
+  -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
 }
 
 .order-3 {
+  -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
 }
 
 .order-4 {
+  -webkit-order: 4;
   -ms-flex-order: 4;
   order: 4;
 }
 
 .order-5 {
+  -webkit-order: 5;
   -ms-flex-order: 5;
   order: 5;
 }
 
 .order-6 {
+  -webkit-order: 6;
   -ms-flex-order: 6;
   order: 6;
 }
 
 .order-7 {
+  -webkit-order: 7;
   -ms-flex-order: 7;
   order: 7;
 }
 
 .order-8 {
+  -webkit-order: 8;
   -ms-flex-order: 8;
   order: 8;
 }
 
 .order-9 {
+  -webkit-order: 9;
   -ms-flex-order: 9;
   order: 9;
 }
 
 .order-10 {
+  -webkit-order: 10;
   -ms-flex-order: 10;
   order: 10;
 }
 
 .order-11 {
+  -webkit-order: 11;
   -ms-flex-order: 11;
   order: 11;
 }
 
 .order-12 {
+  -webkit-order: 12;
   -ms-flex-order: 12;
   order: 12;
 }
@@ -864,165 +901,201 @@ pre code {
 
 @media (min-width: 576px) {
   .col-sm {
+    -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
+    -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
     max-width: 100%;
   }
   .row-cols-sm-1 > * {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .row-cols-sm-2 > * {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .row-cols-sm-3 > * {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .row-cols-sm-4 > * {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .row-cols-sm-5 > * {
+    -webkit-flex: 0 0 20%;
     -ms-flex: 0 0 20%;
     flex: 0 0 20%;
     max-width: 20%;
   }
   .row-cols-sm-6 > * {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-sm-auto {
+    -webkit-flex: 0 0 auto;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
   }
   .col-sm-1 {
+    -webkit-flex: 0 0 8.333333%;
     -ms-flex: 0 0 8.333333%;
     flex: 0 0 8.333333%;
     max-width: 8.333333%;
   }
   .col-sm-2 {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-sm-3 {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .col-sm-4 {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .col-sm-5 {
+    -webkit-flex: 0 0 41.666667%;
     -ms-flex: 0 0 41.666667%;
     flex: 0 0 41.666667%;
     max-width: 41.666667%;
   }
   .col-sm-6 {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .col-sm-7 {
+    -webkit-flex: 0 0 58.333333%;
     -ms-flex: 0 0 58.333333%;
     flex: 0 0 58.333333%;
     max-width: 58.333333%;
   }
   .col-sm-8 {
+    -webkit-flex: 0 0 66.666667%;
     -ms-flex: 0 0 66.666667%;
     flex: 0 0 66.666667%;
     max-width: 66.666667%;
   }
   .col-sm-9 {
+    -webkit-flex: 0 0 75%;
     -ms-flex: 0 0 75%;
     flex: 0 0 75%;
     max-width: 75%;
   }
   .col-sm-10 {
+    -webkit-flex: 0 0 83.333333%;
     -ms-flex: 0 0 83.333333%;
     flex: 0 0 83.333333%;
     max-width: 83.333333%;
   }
   .col-sm-11 {
+    -webkit-flex: 0 0 91.666667%;
     -ms-flex: 0 0 91.666667%;
     flex: 0 0 91.666667%;
     max-width: 91.666667%;
   }
   .col-sm-12 {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .order-sm-first {
+    -webkit-order: -1;
     -ms-flex-order: -1;
     order: -1;
   }
   .order-sm-last {
+    -webkit-order: 13;
     -ms-flex-order: 13;
     order: 13;
   }
   .order-sm-0 {
+    -webkit-order: 0;
     -ms-flex-order: 0;
     order: 0;
   }
   .order-sm-1 {
+    -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
   }
   .order-sm-2 {
+    -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
   }
   .order-sm-3 {
+    -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
   }
   .order-sm-4 {
+    -webkit-order: 4;
     -ms-flex-order: 4;
     order: 4;
   }
   .order-sm-5 {
+    -webkit-order: 5;
     -ms-flex-order: 5;
     order: 5;
   }
   .order-sm-6 {
+    -webkit-order: 6;
     -ms-flex-order: 6;
     order: 6;
   }
   .order-sm-7 {
+    -webkit-order: 7;
     -ms-flex-order: 7;
     order: 7;
   }
   .order-sm-8 {
+    -webkit-order: 8;
     -ms-flex-order: 8;
     order: 8;
   }
   .order-sm-9 {
+    -webkit-order: 9;
     -ms-flex-order: 9;
     order: 9;
   }
   .order-sm-10 {
+    -webkit-order: 10;
     -ms-flex-order: 10;
     order: 10;
   }
   .order-sm-11 {
+    -webkit-order: 11;
     -ms-flex-order: 11;
     order: 11;
   }
   .order-sm-12 {
+    -webkit-order: 12;
     -ms-flex-order: 12;
     order: 12;
   }
@@ -1066,165 +1139,201 @@ pre code {
 
 @media (min-width: 768px) {
   .col-md {
+    -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
+    -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
     max-width: 100%;
   }
   .row-cols-md-1 > * {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .row-cols-md-2 > * {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .row-cols-md-3 > * {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .row-cols-md-4 > * {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .row-cols-md-5 > * {
+    -webkit-flex: 0 0 20%;
     -ms-flex: 0 0 20%;
     flex: 0 0 20%;
     max-width: 20%;
   }
   .row-cols-md-6 > * {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-md-auto {
+    -webkit-flex: 0 0 auto;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
   }
   .col-md-1 {
+    -webkit-flex: 0 0 8.333333%;
     -ms-flex: 0 0 8.333333%;
     flex: 0 0 8.333333%;
     max-width: 8.333333%;
   }
   .col-md-2 {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-md-3 {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .col-md-4 {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .col-md-5 {
+    -webkit-flex: 0 0 41.666667%;
     -ms-flex: 0 0 41.666667%;
     flex: 0 0 41.666667%;
     max-width: 41.666667%;
   }
   .col-md-6 {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .col-md-7 {
+    -webkit-flex: 0 0 58.333333%;
     -ms-flex: 0 0 58.333333%;
     flex: 0 0 58.333333%;
     max-width: 58.333333%;
   }
   .col-md-8 {
+    -webkit-flex: 0 0 66.666667%;
     -ms-flex: 0 0 66.666667%;
     flex: 0 0 66.666667%;
     max-width: 66.666667%;
   }
   .col-md-9 {
+    -webkit-flex: 0 0 75%;
     -ms-flex: 0 0 75%;
     flex: 0 0 75%;
     max-width: 75%;
   }
   .col-md-10 {
+    -webkit-flex: 0 0 83.333333%;
     -ms-flex: 0 0 83.333333%;
     flex: 0 0 83.333333%;
     max-width: 83.333333%;
   }
   .col-md-11 {
+    -webkit-flex: 0 0 91.666667%;
     -ms-flex: 0 0 91.666667%;
     flex: 0 0 91.666667%;
     max-width: 91.666667%;
   }
   .col-md-12 {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .order-md-first {
+    -webkit-order: -1;
     -ms-flex-order: -1;
     order: -1;
   }
   .order-md-last {
+    -webkit-order: 13;
     -ms-flex-order: 13;
     order: 13;
   }
   .order-md-0 {
+    -webkit-order: 0;
     -ms-flex-order: 0;
     order: 0;
   }
   .order-md-1 {
+    -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
   }
   .order-md-2 {
+    -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
   }
   .order-md-3 {
+    -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
   }
   .order-md-4 {
+    -webkit-order: 4;
     -ms-flex-order: 4;
     order: 4;
   }
   .order-md-5 {
+    -webkit-order: 5;
     -ms-flex-order: 5;
     order: 5;
   }
   .order-md-6 {
+    -webkit-order: 6;
     -ms-flex-order: 6;
     order: 6;
   }
   .order-md-7 {
+    -webkit-order: 7;
     -ms-flex-order: 7;
     order: 7;
   }
   .order-md-8 {
+    -webkit-order: 8;
     -ms-flex-order: 8;
     order: 8;
   }
   .order-md-9 {
+    -webkit-order: 9;
     -ms-flex-order: 9;
     order: 9;
   }
   .order-md-10 {
+    -webkit-order: 10;
     -ms-flex-order: 10;
     order: 10;
   }
   .order-md-11 {
+    -webkit-order: 11;
     -ms-flex-order: 11;
     order: 11;
   }
   .order-md-12 {
+    -webkit-order: 12;
     -ms-flex-order: 12;
     order: 12;
   }
@@ -1268,165 +1377,201 @@ pre code {
 
 @media (min-width: 992px) {
   .col-lg {
+    -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
+    -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
     max-width: 100%;
   }
   .row-cols-lg-1 > * {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .row-cols-lg-2 > * {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .row-cols-lg-3 > * {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .row-cols-lg-4 > * {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .row-cols-lg-5 > * {
+    -webkit-flex: 0 0 20%;
     -ms-flex: 0 0 20%;
     flex: 0 0 20%;
     max-width: 20%;
   }
   .row-cols-lg-6 > * {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-lg-auto {
+    -webkit-flex: 0 0 auto;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
   }
   .col-lg-1 {
+    -webkit-flex: 0 0 8.333333%;
     -ms-flex: 0 0 8.333333%;
     flex: 0 0 8.333333%;
     max-width: 8.333333%;
   }
   .col-lg-2 {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-lg-3 {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .col-lg-4 {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .col-lg-5 {
+    -webkit-flex: 0 0 41.666667%;
     -ms-flex: 0 0 41.666667%;
     flex: 0 0 41.666667%;
     max-width: 41.666667%;
   }
   .col-lg-6 {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .col-lg-7 {
+    -webkit-flex: 0 0 58.333333%;
     -ms-flex: 0 0 58.333333%;
     flex: 0 0 58.333333%;
     max-width: 58.333333%;
   }
   .col-lg-8 {
+    -webkit-flex: 0 0 66.666667%;
     -ms-flex: 0 0 66.666667%;
     flex: 0 0 66.666667%;
     max-width: 66.666667%;
   }
   .col-lg-9 {
+    -webkit-flex: 0 0 75%;
     -ms-flex: 0 0 75%;
     flex: 0 0 75%;
     max-width: 75%;
   }
   .col-lg-10 {
+    -webkit-flex: 0 0 83.333333%;
     -ms-flex: 0 0 83.333333%;
     flex: 0 0 83.333333%;
     max-width: 83.333333%;
   }
   .col-lg-11 {
+    -webkit-flex: 0 0 91.666667%;
     -ms-flex: 0 0 91.666667%;
     flex: 0 0 91.666667%;
     max-width: 91.666667%;
   }
   .col-lg-12 {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .order-lg-first {
+    -webkit-order: -1;
     -ms-flex-order: -1;
     order: -1;
   }
   .order-lg-last {
+    -webkit-order: 13;
     -ms-flex-order: 13;
     order: 13;
   }
   .order-lg-0 {
+    -webkit-order: 0;
     -ms-flex-order: 0;
     order: 0;
   }
   .order-lg-1 {
+    -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
   }
   .order-lg-2 {
+    -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
   }
   .order-lg-3 {
+    -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
   }
   .order-lg-4 {
+    -webkit-order: 4;
     -ms-flex-order: 4;
     order: 4;
   }
   .order-lg-5 {
+    -webkit-order: 5;
     -ms-flex-order: 5;
     order: 5;
   }
   .order-lg-6 {
+    -webkit-order: 6;
     -ms-flex-order: 6;
     order: 6;
   }
   .order-lg-7 {
+    -webkit-order: 7;
     -ms-flex-order: 7;
     order: 7;
   }
   .order-lg-8 {
+    -webkit-order: 8;
     -ms-flex-order: 8;
     order: 8;
   }
   .order-lg-9 {
+    -webkit-order: 9;
     -ms-flex-order: 9;
     order: 9;
   }
   .order-lg-10 {
+    -webkit-order: 10;
     -ms-flex-order: 10;
     order: 10;
   }
   .order-lg-11 {
+    -webkit-order: 11;
     -ms-flex-order: 11;
     order: 11;
   }
   .order-lg-12 {
+    -webkit-order: 12;
     -ms-flex-order: 12;
     order: 12;
   }
@@ -1470,165 +1615,201 @@ pre code {
 
 @media (min-width: 1200px) {
   .col-xl {
+    -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
+    -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
     max-width: 100%;
   }
   .row-cols-xl-1 > * {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .row-cols-xl-2 > * {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .row-cols-xl-3 > * {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .row-cols-xl-4 > * {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .row-cols-xl-5 > * {
+    -webkit-flex: 0 0 20%;
     -ms-flex: 0 0 20%;
     flex: 0 0 20%;
     max-width: 20%;
   }
   .row-cols-xl-6 > * {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-xl-auto {
+    -webkit-flex: 0 0 auto;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
   }
   .col-xl-1 {
+    -webkit-flex: 0 0 8.333333%;
     -ms-flex: 0 0 8.333333%;
     flex: 0 0 8.333333%;
     max-width: 8.333333%;
   }
   .col-xl-2 {
+    -webkit-flex: 0 0 16.666667%;
     -ms-flex: 0 0 16.666667%;
     flex: 0 0 16.666667%;
     max-width: 16.666667%;
   }
   .col-xl-3 {
+    -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
     flex: 0 0 25%;
     max-width: 25%;
   }
   .col-xl-4 {
+    -webkit-flex: 0 0 33.333333%;
     -ms-flex: 0 0 33.333333%;
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
   }
   .col-xl-5 {
+    -webkit-flex: 0 0 41.666667%;
     -ms-flex: 0 0 41.666667%;
     flex: 0 0 41.666667%;
     max-width: 41.666667%;
   }
   .col-xl-6 {
+    -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
     max-width: 50%;
   }
   .col-xl-7 {
+    -webkit-flex: 0 0 58.333333%;
     -ms-flex: 0 0 58.333333%;
     flex: 0 0 58.333333%;
     max-width: 58.333333%;
   }
   .col-xl-8 {
+    -webkit-flex: 0 0 66.666667%;
     -ms-flex: 0 0 66.666667%;
     flex: 0 0 66.666667%;
     max-width: 66.666667%;
   }
   .col-xl-9 {
+    -webkit-flex: 0 0 75%;
     -ms-flex: 0 0 75%;
     flex: 0 0 75%;
     max-width: 75%;
   }
   .col-xl-10 {
+    -webkit-flex: 0 0 83.333333%;
     -ms-flex: 0 0 83.333333%;
     flex: 0 0 83.333333%;
     max-width: 83.333333%;
   }
   .col-xl-11 {
+    -webkit-flex: 0 0 91.666667%;
     -ms-flex: 0 0 91.666667%;
     flex: 0 0 91.666667%;
     max-width: 91.666667%;
   }
   .col-xl-12 {
+    -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
     flex: 0 0 100%;
     max-width: 100%;
   }
   .order-xl-first {
+    -webkit-order: -1;
     -ms-flex-order: -1;
     order: -1;
   }
   .order-xl-last {
+    -webkit-order: 13;
     -ms-flex-order: 13;
     order: 13;
   }
   .order-xl-0 {
+    -webkit-order: 0;
     -ms-flex-order: 0;
     order: 0;
   }
   .order-xl-1 {
+    -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
   }
   .order-xl-2 {
+    -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
   }
   .order-xl-3 {
+    -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
   }
   .order-xl-4 {
+    -webkit-order: 4;
     -ms-flex-order: 4;
     order: 4;
   }
   .order-xl-5 {
+    -webkit-order: 5;
     -ms-flex-order: 5;
     order: 5;
   }
   .order-xl-6 {
+    -webkit-order: 6;
     -ms-flex-order: 6;
     order: 6;
   }
   .order-xl-7 {
+    -webkit-order: 7;
     -ms-flex-order: 7;
     order: 7;
   }
   .order-xl-8 {
+    -webkit-order: 8;
     -ms-flex-order: 8;
     order: 8;
   }
   .order-xl-9 {
+    -webkit-order: 9;
     -ms-flex-order: 9;
     order: 9;
   }
   .order-xl-10 {
+    -webkit-order: 10;
     -ms-flex-order: 10;
     order: 10;
   }
   .order-xl-11 {
+    -webkit-order: 11;
     -ms-flex-order: 11;
     order: 11;
   }
   .order-xl-12 {
+    -webkit-order: 12;
     -ms-flex-order: 12;
     order: 12;
   }
@@ -2179,8 +2360,10 @@ textarea.form-control {
 }
 
 .form-row {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   margin-right: -5px;
@@ -2215,8 +2398,10 @@ textarea.form-control {
 }
 
 .form-check-inline {
+  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   padding-left: 0;
@@ -2254,6 +2439,11 @@ textarea.form-control {
   border-radius: 0.25rem;
 }
 
+.form-row > .col > .valid-tooltip,
+.form-row > [class*="col-"] > .valid-tooltip {
+  left: 5px;
+}
+
 .was-validated :valid ~ .valid-feedback,
 .was-validated :valid ~ .valid-tooltip,
 .is-valid ~ .valid-feedback,
@@ -2283,7 +2473,7 @@ textarea.form-control {
 .was-validated .custom-select:valid, .custom-select.is-valid {
   border-color: #28a745;
   padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+  background: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;
 }
 
 .was-validated .custom-select:valid:focus, .custom-select.is-valid:focus {
@@ -2355,6 +2545,11 @@ textarea.form-control {
   border-radius: 0.25rem;
 }
 
+.form-row > .col > .invalid-tooltip,
+.form-row > [class*="col-"] > .invalid-tooltip {
+  left: 5px;
+}
+
 .was-validated :invalid ~ .invalid-feedback,
 .was-validated :invalid ~ .invalid-tooltip,
 .is-invalid ~ .invalid-feedback,
@@ -2384,7 +2579,7 @@ textarea.form-control {
 .was-validated .custom-select:invalid, .custom-select.is-invalid {
   border-color: #dc3545;
   padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+  background: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;
 }
 
 .was-validated .custom-select:invalid:focus, .custom-select.is-invalid:focus {
@@ -2433,10 +2628,13 @@ textarea.form-control {
 }
 
 .form-inline {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
 }
@@ -2447,21 +2645,28 @@ textarea.form-control {
 
 @media (min-width: 576px) {
   .form-inline label {
+    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+    -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
+    -webkit-justify-content: center;
     -ms-flex-pack: center;
     justify-content: center;
     margin-bottom: 0;
   }
   .form-inline .form-group {
+    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+    -webkit-flex: 0 0 auto;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
+    -webkit-flex-flow: row wrap;
     -ms-flex-flow: row wrap;
     flex-flow: row wrap;
+    -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
     margin-bottom: 0;
@@ -2479,10 +2684,13 @@ textarea.form-control {
     width: auto;
   }
   .form-inline .form-check {
+    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+    -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
+    -webkit-justify-content: center;
     -ms-flex-pack: center;
     justify-content: center;
     width: auto;
@@ -2490,6 +2698,7 @@ textarea.form-control {
   }
   .form-inline .form-check-input {
     position: relative;
+    -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
     margin-top: 0;
@@ -2497,8 +2706,10 @@ textarea.form-control {
     margin-left: 0;
   }
   .form-inline .custom-control {
+    -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
+    -webkit-justify-content: center;
     -ms-flex-pack: center;
     justify-content: center;
   }
@@ -3452,6 +3663,7 @@ input[type="button"].btn-block {
 .btn-group,
 .btn-group-vertical {
   position: relative;
+  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
   vertical-align: middle;
@@ -3460,6 +3672,7 @@ input[type="button"].btn-block {
 .btn-group > .btn,
 .btn-group-vertical > .btn {
   position: relative;
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
@@ -3477,10 +3690,13 @@ input[type="button"].btn-block {
 }
 
 .btn-toolbar {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
 }
@@ -3540,10 +3756,13 @@ input[type="button"].btn-block {
 }
 
 .btn-group-vertical {
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-align-items: flex-start;
   -ms-flex-align: start;
   align-items: flex-start;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
 }
@@ -3586,10 +3805,13 @@ input[type="button"].btn-block {
 
 .input-group {
   position: relative;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-align-items: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
   width: 100%;
@@ -3600,6 +3822,7 @@ input[type="button"].btn-block {
 .input-group > .custom-select,
 .input-group > .custom-file {
   position: relative;
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   width: 1%;
@@ -3632,12 +3855,6 @@ input[type="button"].btn-block {
   z-index: 4;
 }
 
-.input-group > .form-control:not(:last-child),
-.input-group > .custom-select:not(:last-child) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
 .input-group > .form-control:not(:first-child),
 .input-group > .custom-select:not(:first-child) {
   border-top-left-radius: 0;
@@ -3645,25 +3862,37 @@ input[type="button"].btn-block {
 }
 
 .input-group > .custom-file {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
 .input-group > .custom-file:not(:last-child) .custom-file-label,
-.input-group > .custom-file:not(:last-child) .custom-file-label::after {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
 .input-group > .custom-file:not(:first-child) .custom-file-label {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
 
+.input-group:not(.has-validation) > .form-control:not(:last-child),
+.input-group:not(.has-validation) > .custom-select:not(:last-child),
+.input-group:not(.has-validation) > .custom-file:not(:last-child) .custom-file-label::after {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group.has-validation > .form-control:nth-last-child(n + 3),
+.input-group.has-validation > .custom-select:nth-last-child(n + 3),
+.input-group.has-validation > .custom-file:nth-last-child(n + 3) .custom-file-label::after {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .input-group-prepend,
 .input-group-append {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
@@ -3699,8 +3928,10 @@ input[type="button"].btn-block {
 }
 
 .input-group-text {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   padding: 0.375rem 0.75rem;
@@ -3762,8 +3993,10 @@ input[type="button"].btn-block {
 
 .input-group > .input-group-prepend > .btn,
 .input-group > .input-group-prepend > .input-group-text,
-.input-group > .input-group-append:not(:last-child) > .btn,
-.input-group > .input-group-append:not(:last-child) > .input-group-text,
+.input-group:not(.has-validation) > .input-group-append:not(:last-child) > .btn,
+.input-group:not(.has-validation) > .input-group-append:not(:last-child) > .input-group-text,
+.input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .btn,
+.input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .input-group-text,
 .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
   border-top-right-radius: 0;
@@ -3791,6 +4024,7 @@ input[type="button"].btn-block {
 }
 
 .custom-control-inline {
+  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
   margin-right: 1rem;
@@ -3863,7 +4097,7 @@ input[type="button"].btn-block {
   width: 1rem;
   height: 1rem;
   content: "";
-  background: no-repeat 50% / 50% 50%;
+  background: 50% / 50% 50% no-repeat;
 }
 
 .custom-checkbox .custom-control-label::before {
@@ -3922,7 +4156,9 @@ input[type="button"].btn-block {
   height: calc(1rem - 4px);
   background-color: #adb5bd;
   border-radius: 0.5rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;
   transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -3933,6 +4169,7 @@ input[type="button"].btn-block {
 
 .custom-switch .custom-control-input:checked ~ .custom-control-label::after {
   background-color: #dee2e6;
+  -webkit-transform: translateX(0.75rem);
   transform: translateX(0.75rem);
 }
 
@@ -3950,7 +4187,7 @@ input[type="button"].btn-block {
   line-height: 1.5;
   color: #495057;
   vertical-align: middle;
-  background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") no-repeat right 0.75rem center/8px 10px;
+  background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") right 0.75rem center/8px 10px no-repeat;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
@@ -4020,6 +4257,7 @@ input[type="button"].btn-block {
   width: 100%;
   height: calc(2.25rem + 2px);
   margin: 0;
+  overflow: hidden;
   opacity: 0;
 }
 
@@ -4049,6 +4287,7 @@ input[type="button"].btn-block {
   z-index: 1;
   height: calc(2.25rem + 2px);
   padding: 0.375rem 0.75rem;
+  overflow: hidden;
   font-weight: 400;
   line-height: 1.5;
   color: #495057;
@@ -4086,7 +4325,7 @@ input[type="button"].btn-block {
 }
 
 .custom-range:focus {
-  outline: none;
+  outline: 0;
 }
 
 .custom-range:focus::-webkit-slider-thumb {
@@ -4259,8 +4498,10 @@ input[type="button"].btn-block {
 }
 
 .nav {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   padding-left: 0;
@@ -4287,11 +4528,8 @@ input[type="button"].btn-block {
   border-bottom: 1px solid #dee2e6;
 }
 
-.nav-tabs .nav-item {
-  margin-bottom: -1px;
-}
-
 .nav-tabs .nav-link {
+  margin-bottom: -1px;
   border: 1px solid transparent;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
@@ -4332,6 +4570,7 @@ input[type="button"].btn-block {
 
 .nav-fill > .nav-link,
 .nav-fill .nav-item {
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   text-align: center;
@@ -4339,8 +4578,10 @@ input[type="button"].btn-block {
 
 .nav-justified > .nav-link,
 .nav-justified .nav-item {
+  -webkit-flex-basis: 0;
   -ms-flex-preferred-size: 0;
   flex-basis: 0;
+  -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
   text-align: center;
@@ -4356,12 +4597,16 @@ input[type="button"].btn-block {
 
 .navbar {
   position: relative;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0.5rem 0.5rem;
@@ -4369,12 +4614,16 @@ input[type="button"].btn-block {
 
 .navbar .container,
 .navbar .container-fluid, .navbar .container-sm, .navbar .container-md, .navbar .container-lg, .navbar .container-xl {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
 }
@@ -4394,8 +4643,10 @@ input[type="button"].btn-block {
 }
 
 .navbar-nav {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   padding-left: 0;
@@ -4420,10 +4671,13 @@ input[type="button"].btn-block {
 }
 
 .navbar-collapse {
+  -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
+  -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
 }
@@ -4447,8 +4701,12 @@ input[type="button"].btn-block {
   height: 1.5em;
   vertical-align: middle;
   content: "";
-  background: no-repeat center center;
-  background-size: 100% 100%;
+  background: 50% / 100% 100% no-repeat;
+}
+
+.navbar-nav-scroll {
+  max-height: 75vh;
+  overflow-y: auto;
 }
 
 @media (max-width: 575.98px) {
@@ -4461,12 +4719,15 @@ input[type="button"].btn-block {
 
 @media (min-width: 576px) {
   .navbar-expand-sm {
+    -webkit-flex-flow: row nowrap;
     -ms-flex-flow: row nowrap;
     flex-flow: row nowrap;
+    -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
     justify-content: flex-start;
   }
   .navbar-expand-sm .navbar-nav {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -4479,12 +4740,18 @@ input[type="button"].btn-block {
   }
   .navbar-expand-sm > .container,
   .navbar-expand-sm > .container-fluid, .navbar-expand-sm > .container-sm, .navbar-expand-sm > .container-md, .navbar-expand-sm > .container-lg, .navbar-expand-sm > .container-xl {
+    -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
   }
+  .navbar-expand-sm .navbar-nav-scroll {
+    overflow: visible;
+  }
   .navbar-expand-sm .navbar-collapse {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
+    -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
   }
@@ -4503,12 +4770,15 @@ input[type="button"].btn-block {
 
 @media (min-width: 768px) {
   .navbar-expand-md {
+    -webkit-flex-flow: row nowrap;
     -ms-flex-flow: row nowrap;
     flex-flow: row nowrap;
+    -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
     justify-content: flex-start;
   }
   .navbar-expand-md .navbar-nav {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -4521,12 +4791,18 @@ input[type="button"].btn-block {
   }
   .navbar-expand-md > .container,
   .navbar-expand-md > .container-fluid, .navbar-expand-md > .container-sm, .navbar-expand-md > .container-md, .navbar-expand-md > .container-lg, .navbar-expand-md > .container-xl {
+    -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
   }
+  .navbar-expand-md .navbar-nav-scroll {
+    overflow: visible;
+  }
   .navbar-expand-md .navbar-collapse {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
+    -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
   }
@@ -4545,12 +4821,15 @@ input[type="button"].btn-block {
 
 @media (min-width: 992px) {
   .navbar-expand-lg {
+    -webkit-flex-flow: row nowrap;
     -ms-flex-flow: row nowrap;
     flex-flow: row nowrap;
+    -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
     justify-content: flex-start;
   }
   .navbar-expand-lg .navbar-nav {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -4563,12 +4842,18 @@ input[type="button"].btn-block {
   }
   .navbar-expand-lg > .container,
   .navbar-expand-lg > .container-fluid, .navbar-expand-lg > .container-sm, .navbar-expand-lg > .container-md, .navbar-expand-lg > .container-lg, .navbar-expand-lg > .container-xl {
+    -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
   }
+  .navbar-expand-lg .navbar-nav-scroll {
+    overflow: visible;
+  }
   .navbar-expand-lg .navbar-collapse {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
+    -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
   }
@@ -4587,12 +4872,15 @@ input[type="button"].btn-block {
 
 @media (min-width: 1200px) {
   .navbar-expand-xl {
+    -webkit-flex-flow: row nowrap;
     -ms-flex-flow: row nowrap;
     flex-flow: row nowrap;
+    -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
     justify-content: flex-start;
   }
   .navbar-expand-xl .navbar-nav {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -4605,12 +4893,18 @@ input[type="button"].btn-block {
   }
   .navbar-expand-xl > .container,
   .navbar-expand-xl > .container-fluid, .navbar-expand-xl > .container-sm, .navbar-expand-xl > .container-md, .navbar-expand-xl > .container-lg, .navbar-expand-xl > .container-xl {
+    -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
   }
+  .navbar-expand-xl .navbar-nav-scroll {
+    overflow: visible;
+  }
   .navbar-expand-xl .navbar-collapse {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
+    -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
   }
@@ -4620,8 +4914,10 @@ input[type="button"].btn-block {
 }
 
 .navbar-expand {
+  -webkit-flex-flow: row nowrap;
   -ms-flex-flow: row nowrap;
   flex-flow: row nowrap;
+  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
 }
@@ -4633,6 +4929,7 @@ input[type="button"].btn-block {
 }
 
 .navbar-expand .navbar-nav {
+  -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
@@ -4648,13 +4945,20 @@ input[type="button"].btn-block {
 
 .navbar-expand > .container,
 .navbar-expand > .container-fluid, .navbar-expand > .container-sm, .navbar-expand > .container-md, .navbar-expand > .container-lg, .navbar-expand > .container-xl {
+  -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
 }
 
+.navbar-expand .navbar-nav-scroll {
+  overflow: visible;
+}
+
 .navbar-expand .navbar-collapse {
+  display: -webkit-flex !important;
   display: -ms-flexbox !important;
   display: flex !important;
+  -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
 }
@@ -4761,8 +5065,10 @@ input[type="button"].btn-block {
 
 .card {
   position: relative;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   min-width: 0;
@@ -4801,6 +5107,7 @@ input[type="button"].btn-block {
 }
 
 .card-body {
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   min-height: 1px;
@@ -4874,6 +5181,7 @@ input[type="button"].btn-block {
 .card-img,
 .card-img-top,
 .card-img-bottom {
+  -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
@@ -4897,14 +5205,17 @@ input[type="button"].btn-block {
 
 @media (min-width: 576px) {
   .card-deck {
+    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+    -webkit-flex-flow: row wrap;
     -ms-flex-flow: row wrap;
     flex-flow: row wrap;
     margin-right: -7.5px;
     margin-left: -7.5px;
   }
   .card-deck .card {
+    -webkit-flex: 1 0 0%;
     -ms-flex: 1 0 0%;
     flex: 1 0 0%;
     margin-right: 7.5px;
@@ -4919,12 +5230,15 @@ input[type="button"].btn-block {
 
 @media (min-width: 576px) {
   .card-group {
+    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+    -webkit-flex-flow: row wrap;
     -ms-flex-flow: row wrap;
     flex-flow: row wrap;
   }
   .card-group > .card {
+    -webkit-flex: 1 0 0%;
     -ms-flex: 1 0 0%;
     flex: 1 0 0%;
     margin-bottom: 0;
@@ -5005,8 +5319,10 @@ input[type="button"].btn-block {
 }
 
 .breadcrumb {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   padding: 0.75rem 1rem;
@@ -5016,17 +5332,12 @@ input[type="button"].btn-block {
   border-radius: 0.25rem;
 }
 
-.breadcrumb-item {
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .breadcrumb-item + .breadcrumb-item {
   padding-left: 0.5rem;
 }
 
 .breadcrumb-item + .breadcrumb-item::before {
-  display: inline-block;
+  float: left;
   padding-right: 0.5rem;
   color: #6c757d;
   content: "/";
@@ -5045,6 +5356,7 @@ input[type="button"].btn-block {
 }
 
 .pagination {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   padding-left: 0;
@@ -5472,6 +5784,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 
 .progress {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 1rem;
@@ -5484,10 +5797,13 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 
 .progress-bar {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   overflow: hidden;
@@ -5510,8 +5826,8 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 
 .progress-bar-animated {
-  -webkit-animation: progress-bar-stripes 1s linear infinite;
-  animation: progress-bar-stripes 1s linear infinite;
+  -webkit-animation: 1s linear infinite progress-bar-stripes;
+  animation: 1s linear infinite progress-bar-stripes;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -5522,20 +5838,25 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 
 .media {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
   -ms-flex-align: start;
   align-items: flex-start;
 }
 
 .media-body {
+  -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
 .list-group {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   padding-left: 0;
@@ -5602,6 +5923,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 
 .list-group-horizontal {
+  -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
@@ -5632,6 +5954,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 
 @media (min-width: 576px) {
   .list-group-horizontal-sm {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -5658,6 +5981,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 
 @media (min-width: 768px) {
   .list-group-horizontal-md {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -5684,6 +6008,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 
 @media (min-width: 992px) {
   .list-group-horizontal-lg {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -5710,6 +6035,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 
 @media (min-width: 1200px) {
   .list-group-horizontal-xl {
+    -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
@@ -5904,6 +6230,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .toast {
+  -webkit-flex-basis: 350px;
   -ms-flex-preferred-size: 350px;
   flex-basis: 350px;
   max-width: 350px;
@@ -5934,8 +6261,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .toast-header {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   padding: 0.25rem 0.75rem;
@@ -5980,7 +6309,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .modal.fade .modal-dialog {
+  transition: -webkit-transform 0.3s ease-out;
   transition: transform 0.3s ease-out;
+  transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
+  -webkit-transform: translate(0, -50px);
   transform: translate(0, -50px);
 }
 
@@ -5991,14 +6323,17 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .modal.show .modal-dialog {
+  -webkit-transform: none;
   transform: none;
 }
 
 .modal.modal-static .modal-dialog {
+  -webkit-transform: scale(1.02);
   transform: scale(1.02);
 }
 
 .modal-dialog-scrollable {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   max-height: calc(100% - 1rem);
@@ -6011,6 +6346,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .modal-dialog-scrollable .modal-header,
 .modal-dialog-scrollable .modal-footer {
+  -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
@@ -6020,8 +6356,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .modal-dialog-centered {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   min-height: calc(100% - 1rem);
@@ -6037,8 +6375,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .modal-dialog-centered.modal-dialog-scrollable {
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   height: 100%;
@@ -6054,8 +6394,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .modal-content {
   position: relative;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
@@ -6087,10 +6429,13 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .modal-header {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
   -ms-flex-align: start;
   align-items: flex-start;
+  -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 1rem;
@@ -6111,18 +6456,23 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .modal-body {
   position: relative;
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   padding: 1rem;
 }
 
 .modal-footer {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
   padding: 0.75rem;
@@ -6487,7 +6837,9 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   margin-right: -100%;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
+  transition: -webkit-transform 0.6s ease;
   transition: transform 0.6s ease;
+  transition: transform 0.6s ease, -webkit-transform 0.6s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -6504,17 +6856,20 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .carousel-item-next:not(.carousel-item-left),
 .active.carousel-item-right {
+  -webkit-transform: translateX(100%);
   transform: translateX(100%);
 }
 
 .carousel-item-prev:not(.carousel-item-right),
 .active.carousel-item-left {
+  -webkit-transform: translateX(-100%);
   transform: translateX(-100%);
 }
 
 .carousel-fade .carousel-item {
   opacity: 0;
   transition-property: opacity;
+  -webkit-transform: none;
   transform: none;
 }
 
@@ -6545,10 +6900,13 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   top: 0;
   bottom: 0;
   z-index: 1;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   width: 15%;
@@ -6587,7 +6945,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   display: inline-block;
   width: 20px;
   height: 20px;
-  background: no-repeat 50% / 100% 100%;
+  background: 50% / 100% 100% no-repeat;
 }
 
 .carousel-control-prev-icon {
@@ -6604,8 +6962,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   bottom: 0;
   left: 0;
   z-index: 15;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   padding-left: 0;
@@ -6616,6 +6976,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .carousel-indicators li {
   box-sizing: content-box;
+  -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: 30px;
@@ -6656,12 +7017,14 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 @-webkit-keyframes spinner-border {
   to {
+    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
 
 @keyframes spinner-border {
   to {
+    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
@@ -6674,8 +7037,8 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   border: 0.25em solid currentColor;
   border-right-color: transparent;
   border-radius: 50%;
-  -webkit-animation: spinner-border .75s linear infinite;
-  animation: spinner-border .75s linear infinite;
+  -webkit-animation: .75s linear infinite spinner-border;
+  animation: .75s linear infinite spinner-border;
 }
 
 .spinner-border-sm {
@@ -6686,20 +7049,24 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 @-webkit-keyframes spinner-grow {
   0% {
+    -webkit-transform: scale(0);
     transform: scale(0);
   }
   50% {
     opacity: 1;
+    -webkit-transform: none;
     transform: none;
   }
 }
 
 @keyframes spinner-grow {
   0% {
+    -webkit-transform: scale(0);
     transform: scale(0);
   }
   50% {
     opacity: 1;
+    -webkit-transform: none;
     transform: none;
   }
 }
@@ -6712,13 +7079,21 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   background-color: currentColor;
   border-radius: 50%;
   opacity: 0;
-  -webkit-animation: spinner-grow .75s linear infinite;
-  animation: spinner-grow .75s linear infinite;
+  -webkit-animation: .75s linear infinite spinner-grow;
+  animation: .75s linear infinite spinner-grow;
 }
 
 .spinner-grow-sm {
   width: 1rem;
   height: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner-border,
+  .spinner-grow {
+    -webkit-animation-duration: 1.5s;
+    animation-duration: 1.5s;
+  }
 }
 
 .align-baseline {
@@ -6988,11 +7363,13 @@ button.bg-dark:focus {
 }
 
 .d-flex {
+  display: -webkit-flex !important;
   display: -ms-flexbox !important;
   display: flex !important;
 }
 
 .d-inline-flex {
+  display: -webkit-inline-flex !important;
   display: -ms-inline-flexbox !important;
   display: inline-flex !important;
 }
@@ -7020,10 +7397,12 @@ button.bg-dark:focus {
     display: table-cell !important;
   }
   .d-sm-flex {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
   }
   .d-sm-inline-flex {
+    display: -webkit-inline-flex !important;
     display: -ms-inline-flexbox !important;
     display: inline-flex !important;
   }
@@ -7052,10 +7431,12 @@ button.bg-dark:focus {
     display: table-cell !important;
   }
   .d-md-flex {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
   }
   .d-md-inline-flex {
+    display: -webkit-inline-flex !important;
     display: -ms-inline-flexbox !important;
     display: inline-flex !important;
   }
@@ -7084,10 +7465,12 @@ button.bg-dark:focus {
     display: table-cell !important;
   }
   .d-lg-flex {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
   }
   .d-lg-inline-flex {
+    display: -webkit-inline-flex !important;
     display: -ms-inline-flexbox !important;
     display: inline-flex !important;
   }
@@ -7116,10 +7499,12 @@ button.bg-dark:focus {
     display: table-cell !important;
   }
   .d-xl-flex {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
   }
   .d-xl-inline-flex {
+    display: -webkit-inline-flex !important;
     display: -ms-inline-flexbox !important;
     display: inline-flex !important;
   }
@@ -7148,10 +7533,12 @@ button.bg-dark:focus {
     display: table-cell !important;
   }
   .d-print-flex {
+    display: -webkit-flex !important;
     display: -ms-flexbox !important;
     display: flex !important;
   }
   .d-print-inline-flex {
+    display: -webkit-inline-flex !important;
     display: -ms-inline-flexbox !important;
     display: inline-flex !important;
   }
@@ -7201,309 +7588,377 @@ button.bg-dark:focus {
 }
 
 .flex-row {
+  -webkit-flex-direction: row !important;
   -ms-flex-direction: row !important;
   flex-direction: row !important;
 }
 
 .flex-column {
+  -webkit-flex-direction: column !important;
   -ms-flex-direction: column !important;
   flex-direction: column !important;
 }
 
 .flex-row-reverse {
+  -webkit-flex-direction: row-reverse !important;
   -ms-flex-direction: row-reverse !important;
   flex-direction: row-reverse !important;
 }
 
 .flex-column-reverse {
+  -webkit-flex-direction: column-reverse !important;
   -ms-flex-direction: column-reverse !important;
   flex-direction: column-reverse !important;
 }
 
 .flex-wrap {
+  -webkit-flex-wrap: wrap !important;
   -ms-flex-wrap: wrap !important;
   flex-wrap: wrap !important;
 }
 
 .flex-nowrap {
+  -webkit-flex-wrap: nowrap !important;
   -ms-flex-wrap: nowrap !important;
   flex-wrap: nowrap !important;
 }
 
 .flex-wrap-reverse {
+  -webkit-flex-wrap: wrap-reverse !important;
   -ms-flex-wrap: wrap-reverse !important;
   flex-wrap: wrap-reverse !important;
 }
 
 .flex-fill {
+  -webkit-flex: 1 1 auto !important;
   -ms-flex: 1 1 auto !important;
   flex: 1 1 auto !important;
 }
 
 .flex-grow-0 {
+  -webkit-flex-grow: 0 !important;
   -ms-flex-positive: 0 !important;
   flex-grow: 0 !important;
 }
 
 .flex-grow-1 {
+  -webkit-flex-grow: 1 !important;
   -ms-flex-positive: 1 !important;
   flex-grow: 1 !important;
 }
 
 .flex-shrink-0 {
+  -webkit-flex-shrink: 0 !important;
   -ms-flex-negative: 0 !important;
   flex-shrink: 0 !important;
 }
 
 .flex-shrink-1 {
+  -webkit-flex-shrink: 1 !important;
   -ms-flex-negative: 1 !important;
   flex-shrink: 1 !important;
 }
 
 .justify-content-start {
+  -webkit-justify-content: flex-start !important;
   -ms-flex-pack: start !important;
   justify-content: flex-start !important;
 }
 
 .justify-content-end {
+  -webkit-justify-content: flex-end !important;
   -ms-flex-pack: end !important;
   justify-content: flex-end !important;
 }
 
 .justify-content-center {
+  -webkit-justify-content: center !important;
   -ms-flex-pack: center !important;
   justify-content: center !important;
 }
 
 .justify-content-between {
+  -webkit-justify-content: space-between !important;
   -ms-flex-pack: justify !important;
   justify-content: space-between !important;
 }
 
 .justify-content-around {
+  -webkit-justify-content: space-around !important;
   -ms-flex-pack: distribute !important;
   justify-content: space-around !important;
 }
 
 .align-items-start {
+  -webkit-align-items: flex-start !important;
   -ms-flex-align: start !important;
   align-items: flex-start !important;
 }
 
 .align-items-end {
+  -webkit-align-items: flex-end !important;
   -ms-flex-align: end !important;
   align-items: flex-end !important;
 }
 
 .align-items-center {
+  -webkit-align-items: center !important;
   -ms-flex-align: center !important;
   align-items: center !important;
 }
 
 .align-items-baseline {
+  -webkit-align-items: baseline !important;
   -ms-flex-align: baseline !important;
   align-items: baseline !important;
 }
 
 .align-items-stretch {
+  -webkit-align-items: stretch !important;
   -ms-flex-align: stretch !important;
   align-items: stretch !important;
 }
 
 .align-content-start {
+  -webkit-align-content: flex-start !important;
   -ms-flex-line-pack: start !important;
   align-content: flex-start !important;
 }
 
 .align-content-end {
+  -webkit-align-content: flex-end !important;
   -ms-flex-line-pack: end !important;
   align-content: flex-end !important;
 }
 
 .align-content-center {
+  -webkit-align-content: center !important;
   -ms-flex-line-pack: center !important;
   align-content: center !important;
 }
 
 .align-content-between {
+  -webkit-align-content: space-between !important;
   -ms-flex-line-pack: justify !important;
   align-content: space-between !important;
 }
 
 .align-content-around {
+  -webkit-align-content: space-around !important;
   -ms-flex-line-pack: distribute !important;
   align-content: space-around !important;
 }
 
 .align-content-stretch {
+  -webkit-align-content: stretch !important;
   -ms-flex-line-pack: stretch !important;
   align-content: stretch !important;
 }
 
 .align-self-auto {
+  -webkit-align-self: auto !important;
   -ms-flex-item-align: auto !important;
   align-self: auto !important;
 }
 
 .align-self-start {
+  -webkit-align-self: flex-start !important;
   -ms-flex-item-align: start !important;
   align-self: flex-start !important;
 }
 
 .align-self-end {
+  -webkit-align-self: flex-end !important;
   -ms-flex-item-align: end !important;
   align-self: flex-end !important;
 }
 
 .align-self-center {
+  -webkit-align-self: center !important;
   -ms-flex-item-align: center !important;
   align-self: center !important;
 }
 
 .align-self-baseline {
+  -webkit-align-self: baseline !important;
   -ms-flex-item-align: baseline !important;
   align-self: baseline !important;
 }
 
 .align-self-stretch {
+  -webkit-align-self: stretch !important;
   -ms-flex-item-align: stretch !important;
   align-self: stretch !important;
 }
 
 @media (min-width: 576px) {
   .flex-sm-row {
+    -webkit-flex-direction: row !important;
     -ms-flex-direction: row !important;
     flex-direction: row !important;
   }
   .flex-sm-column {
+    -webkit-flex-direction: column !important;
     -ms-flex-direction: column !important;
     flex-direction: column !important;
   }
   .flex-sm-row-reverse {
+    -webkit-flex-direction: row-reverse !important;
     -ms-flex-direction: row-reverse !important;
     flex-direction: row-reverse !important;
   }
   .flex-sm-column-reverse {
+    -webkit-flex-direction: column-reverse !important;
     -ms-flex-direction: column-reverse !important;
     flex-direction: column-reverse !important;
   }
   .flex-sm-wrap {
+    -webkit-flex-wrap: wrap !important;
     -ms-flex-wrap: wrap !important;
     flex-wrap: wrap !important;
   }
   .flex-sm-nowrap {
+    -webkit-flex-wrap: nowrap !important;
     -ms-flex-wrap: nowrap !important;
     flex-wrap: nowrap !important;
   }
   .flex-sm-wrap-reverse {
+    -webkit-flex-wrap: wrap-reverse !important;
     -ms-flex-wrap: wrap-reverse !important;
     flex-wrap: wrap-reverse !important;
   }
   .flex-sm-fill {
+    -webkit-flex: 1 1 auto !important;
     -ms-flex: 1 1 auto !important;
     flex: 1 1 auto !important;
   }
   .flex-sm-grow-0 {
+    -webkit-flex-grow: 0 !important;
     -ms-flex-positive: 0 !important;
     flex-grow: 0 !important;
   }
   .flex-sm-grow-1 {
+    -webkit-flex-grow: 1 !important;
     -ms-flex-positive: 1 !important;
     flex-grow: 1 !important;
   }
   .flex-sm-shrink-0 {
+    -webkit-flex-shrink: 0 !important;
     -ms-flex-negative: 0 !important;
     flex-shrink: 0 !important;
   }
   .flex-sm-shrink-1 {
+    -webkit-flex-shrink: 1 !important;
     -ms-flex-negative: 1 !important;
     flex-shrink: 1 !important;
   }
   .justify-content-sm-start {
+    -webkit-justify-content: flex-start !important;
     -ms-flex-pack: start !important;
     justify-content: flex-start !important;
   }
   .justify-content-sm-end {
+    -webkit-justify-content: flex-end !important;
     -ms-flex-pack: end !important;
     justify-content: flex-end !important;
   }
   .justify-content-sm-center {
+    -webkit-justify-content: center !important;
     -ms-flex-pack: center !important;
     justify-content: center !important;
   }
   .justify-content-sm-between {
+    -webkit-justify-content: space-between !important;
     -ms-flex-pack: justify !important;
     justify-content: space-between !important;
   }
   .justify-content-sm-around {
+    -webkit-justify-content: space-around !important;
     -ms-flex-pack: distribute !important;
     justify-content: space-around !important;
   }
   .align-items-sm-start {
+    -webkit-align-items: flex-start !important;
     -ms-flex-align: start !important;
     align-items: flex-start !important;
   }
   .align-items-sm-end {
+    -webkit-align-items: flex-end !important;
     -ms-flex-align: end !important;
     align-items: flex-end !important;
   }
   .align-items-sm-center {
+    -webkit-align-items: center !important;
     -ms-flex-align: center !important;
     align-items: center !important;
   }
   .align-items-sm-baseline {
+    -webkit-align-items: baseline !important;
     -ms-flex-align: baseline !important;
     align-items: baseline !important;
   }
   .align-items-sm-stretch {
+    -webkit-align-items: stretch !important;
     -ms-flex-align: stretch !important;
     align-items: stretch !important;
   }
   .align-content-sm-start {
+    -webkit-align-content: flex-start !important;
     -ms-flex-line-pack: start !important;
     align-content: flex-start !important;
   }
   .align-content-sm-end {
+    -webkit-align-content: flex-end !important;
     -ms-flex-line-pack: end !important;
     align-content: flex-end !important;
   }
   .align-content-sm-center {
+    -webkit-align-content: center !important;
     -ms-flex-line-pack: center !important;
     align-content: center !important;
   }
   .align-content-sm-between {
+    -webkit-align-content: space-between !important;
     -ms-flex-line-pack: justify !important;
     align-content: space-between !important;
   }
   .align-content-sm-around {
+    -webkit-align-content: space-around !important;
     -ms-flex-line-pack: distribute !important;
     align-content: space-around !important;
   }
   .align-content-sm-stretch {
+    -webkit-align-content: stretch !important;
     -ms-flex-line-pack: stretch !important;
     align-content: stretch !important;
   }
   .align-self-sm-auto {
+    -webkit-align-self: auto !important;
     -ms-flex-item-align: auto !important;
     align-self: auto !important;
   }
   .align-self-sm-start {
+    -webkit-align-self: flex-start !important;
     -ms-flex-item-align: start !important;
     align-self: flex-start !important;
   }
   .align-self-sm-end {
+    -webkit-align-self: flex-end !important;
     -ms-flex-item-align: end !important;
     align-self: flex-end !important;
   }
   .align-self-sm-center {
+    -webkit-align-self: center !important;
     -ms-flex-item-align: center !important;
     align-self: center !important;
   }
   .align-self-sm-baseline {
+    -webkit-align-self: baseline !important;
     -ms-flex-item-align: baseline !important;
     align-self: baseline !important;
   }
   .align-self-sm-stretch {
+    -webkit-align-self: stretch !important;
     -ms-flex-item-align: stretch !important;
     align-self: stretch !important;
   }
@@ -7511,138 +7966,172 @@ button.bg-dark:focus {
 
 @media (min-width: 768px) {
   .flex-md-row {
+    -webkit-flex-direction: row !important;
     -ms-flex-direction: row !important;
     flex-direction: row !important;
   }
   .flex-md-column {
+    -webkit-flex-direction: column !important;
     -ms-flex-direction: column !important;
     flex-direction: column !important;
   }
   .flex-md-row-reverse {
+    -webkit-flex-direction: row-reverse !important;
     -ms-flex-direction: row-reverse !important;
     flex-direction: row-reverse !important;
   }
   .flex-md-column-reverse {
+    -webkit-flex-direction: column-reverse !important;
     -ms-flex-direction: column-reverse !important;
     flex-direction: column-reverse !important;
   }
   .flex-md-wrap {
+    -webkit-flex-wrap: wrap !important;
     -ms-flex-wrap: wrap !important;
     flex-wrap: wrap !important;
   }
   .flex-md-nowrap {
+    -webkit-flex-wrap: nowrap !important;
     -ms-flex-wrap: nowrap !important;
     flex-wrap: nowrap !important;
   }
   .flex-md-wrap-reverse {
+    -webkit-flex-wrap: wrap-reverse !important;
     -ms-flex-wrap: wrap-reverse !important;
     flex-wrap: wrap-reverse !important;
   }
   .flex-md-fill {
+    -webkit-flex: 1 1 auto !important;
     -ms-flex: 1 1 auto !important;
     flex: 1 1 auto !important;
   }
   .flex-md-grow-0 {
+    -webkit-flex-grow: 0 !important;
     -ms-flex-positive: 0 !important;
     flex-grow: 0 !important;
   }
   .flex-md-grow-1 {
+    -webkit-flex-grow: 1 !important;
     -ms-flex-positive: 1 !important;
     flex-grow: 1 !important;
   }
   .flex-md-shrink-0 {
+    -webkit-flex-shrink: 0 !important;
     -ms-flex-negative: 0 !important;
     flex-shrink: 0 !important;
   }
   .flex-md-shrink-1 {
+    -webkit-flex-shrink: 1 !important;
     -ms-flex-negative: 1 !important;
     flex-shrink: 1 !important;
   }
   .justify-content-md-start {
+    -webkit-justify-content: flex-start !important;
     -ms-flex-pack: start !important;
     justify-content: flex-start !important;
   }
   .justify-content-md-end {
+    -webkit-justify-content: flex-end !important;
     -ms-flex-pack: end !important;
     justify-content: flex-end !important;
   }
   .justify-content-md-center {
+    -webkit-justify-content: center !important;
     -ms-flex-pack: center !important;
     justify-content: center !important;
   }
   .justify-content-md-between {
+    -webkit-justify-content: space-between !important;
     -ms-flex-pack: justify !important;
     justify-content: space-between !important;
   }
   .justify-content-md-around {
+    -webkit-justify-content: space-around !important;
     -ms-flex-pack: distribute !important;
     justify-content: space-around !important;
   }
   .align-items-md-start {
+    -webkit-align-items: flex-start !important;
     -ms-flex-align: start !important;
     align-items: flex-start !important;
   }
   .align-items-md-end {
+    -webkit-align-items: flex-end !important;
     -ms-flex-align: end !important;
     align-items: flex-end !important;
   }
   .align-items-md-center {
+    -webkit-align-items: center !important;
     -ms-flex-align: center !important;
     align-items: center !important;
   }
   .align-items-md-baseline {
+    -webkit-align-items: baseline !important;
     -ms-flex-align: baseline !important;
     align-items: baseline !important;
   }
   .align-items-md-stretch {
+    -webkit-align-items: stretch !important;
     -ms-flex-align: stretch !important;
     align-items: stretch !important;
   }
   .align-content-md-start {
+    -webkit-align-content: flex-start !important;
     -ms-flex-line-pack: start !important;
     align-content: flex-start !important;
   }
   .align-content-md-end {
+    -webkit-align-content: flex-end !important;
     -ms-flex-line-pack: end !important;
     align-content: flex-end !important;
   }
   .align-content-md-center {
+    -webkit-align-content: center !important;
     -ms-flex-line-pack: center !important;
     align-content: center !important;
   }
   .align-content-md-between {
+    -webkit-align-content: space-between !important;
     -ms-flex-line-pack: justify !important;
     align-content: space-between !important;
   }
   .align-content-md-around {
+    -webkit-align-content: space-around !important;
     -ms-flex-line-pack: distribute !important;
     align-content: space-around !important;
   }
   .align-content-md-stretch {
+    -webkit-align-content: stretch !important;
     -ms-flex-line-pack: stretch !important;
     align-content: stretch !important;
   }
   .align-self-md-auto {
+    -webkit-align-self: auto !important;
     -ms-flex-item-align: auto !important;
     align-self: auto !important;
   }
   .align-self-md-start {
+    -webkit-align-self: flex-start !important;
     -ms-flex-item-align: start !important;
     align-self: flex-start !important;
   }
   .align-self-md-end {
+    -webkit-align-self: flex-end !important;
     -ms-flex-item-align: end !important;
     align-self: flex-end !important;
   }
   .align-self-md-center {
+    -webkit-align-self: center !important;
     -ms-flex-item-align: center !important;
     align-self: center !important;
   }
   .align-self-md-baseline {
+    -webkit-align-self: baseline !important;
     -ms-flex-item-align: baseline !important;
     align-self: baseline !important;
   }
   .align-self-md-stretch {
+    -webkit-align-self: stretch !important;
     -ms-flex-item-align: stretch !important;
     align-self: stretch !important;
   }
@@ -7650,138 +8139,172 @@ button.bg-dark:focus {
 
 @media (min-width: 992px) {
   .flex-lg-row {
+    -webkit-flex-direction: row !important;
     -ms-flex-direction: row !important;
     flex-direction: row !important;
   }
   .flex-lg-column {
+    -webkit-flex-direction: column !important;
     -ms-flex-direction: column !important;
     flex-direction: column !important;
   }
   .flex-lg-row-reverse {
+    -webkit-flex-direction: row-reverse !important;
     -ms-flex-direction: row-reverse !important;
     flex-direction: row-reverse !important;
   }
   .flex-lg-column-reverse {
+    -webkit-flex-direction: column-reverse !important;
     -ms-flex-direction: column-reverse !important;
     flex-direction: column-reverse !important;
   }
   .flex-lg-wrap {
+    -webkit-flex-wrap: wrap !important;
     -ms-flex-wrap: wrap !important;
     flex-wrap: wrap !important;
   }
   .flex-lg-nowrap {
+    -webkit-flex-wrap: nowrap !important;
     -ms-flex-wrap: nowrap !important;
     flex-wrap: nowrap !important;
   }
   .flex-lg-wrap-reverse {
+    -webkit-flex-wrap: wrap-reverse !important;
     -ms-flex-wrap: wrap-reverse !important;
     flex-wrap: wrap-reverse !important;
   }
   .flex-lg-fill {
+    -webkit-flex: 1 1 auto !important;
     -ms-flex: 1 1 auto !important;
     flex: 1 1 auto !important;
   }
   .flex-lg-grow-0 {
+    -webkit-flex-grow: 0 !important;
     -ms-flex-positive: 0 !important;
     flex-grow: 0 !important;
   }
   .flex-lg-grow-1 {
+    -webkit-flex-grow: 1 !important;
     -ms-flex-positive: 1 !important;
     flex-grow: 1 !important;
   }
   .flex-lg-shrink-0 {
+    -webkit-flex-shrink: 0 !important;
     -ms-flex-negative: 0 !important;
     flex-shrink: 0 !important;
   }
   .flex-lg-shrink-1 {
+    -webkit-flex-shrink: 1 !important;
     -ms-flex-negative: 1 !important;
     flex-shrink: 1 !important;
   }
   .justify-content-lg-start {
+    -webkit-justify-content: flex-start !important;
     -ms-flex-pack: start !important;
     justify-content: flex-start !important;
   }
   .justify-content-lg-end {
+    -webkit-justify-content: flex-end !important;
     -ms-flex-pack: end !important;
     justify-content: flex-end !important;
   }
   .justify-content-lg-center {
+    -webkit-justify-content: center !important;
     -ms-flex-pack: center !important;
     justify-content: center !important;
   }
   .justify-content-lg-between {
+    -webkit-justify-content: space-between !important;
     -ms-flex-pack: justify !important;
     justify-content: space-between !important;
   }
   .justify-content-lg-around {
+    -webkit-justify-content: space-around !important;
     -ms-flex-pack: distribute !important;
     justify-content: space-around !important;
   }
   .align-items-lg-start {
+    -webkit-align-items: flex-start !important;
     -ms-flex-align: start !important;
     align-items: flex-start !important;
   }
   .align-items-lg-end {
+    -webkit-align-items: flex-end !important;
     -ms-flex-align: end !important;
     align-items: flex-end !important;
   }
   .align-items-lg-center {
+    -webkit-align-items: center !important;
     -ms-flex-align: center !important;
     align-items: center !important;
   }
   .align-items-lg-baseline {
+    -webkit-align-items: baseline !important;
     -ms-flex-align: baseline !important;
     align-items: baseline !important;
   }
   .align-items-lg-stretch {
+    -webkit-align-items: stretch !important;
     -ms-flex-align: stretch !important;
     align-items: stretch !important;
   }
   .align-content-lg-start {
+    -webkit-align-content: flex-start !important;
     -ms-flex-line-pack: start !important;
     align-content: flex-start !important;
   }
   .align-content-lg-end {
+    -webkit-align-content: flex-end !important;
     -ms-flex-line-pack: end !important;
     align-content: flex-end !important;
   }
   .align-content-lg-center {
+    -webkit-align-content: center !important;
     -ms-flex-line-pack: center !important;
     align-content: center !important;
   }
   .align-content-lg-between {
+    -webkit-align-content: space-between !important;
     -ms-flex-line-pack: justify !important;
     align-content: space-between !important;
   }
   .align-content-lg-around {
+    -webkit-align-content: space-around !important;
     -ms-flex-line-pack: distribute !important;
     align-content: space-around !important;
   }
   .align-content-lg-stretch {
+    -webkit-align-content: stretch !important;
     -ms-flex-line-pack: stretch !important;
     align-content: stretch !important;
   }
   .align-self-lg-auto {
+    -webkit-align-self: auto !important;
     -ms-flex-item-align: auto !important;
     align-self: auto !important;
   }
   .align-self-lg-start {
+    -webkit-align-self: flex-start !important;
     -ms-flex-item-align: start !important;
     align-self: flex-start !important;
   }
   .align-self-lg-end {
+    -webkit-align-self: flex-end !important;
     -ms-flex-item-align: end !important;
     align-self: flex-end !important;
   }
   .align-self-lg-center {
+    -webkit-align-self: center !important;
     -ms-flex-item-align: center !important;
     align-self: center !important;
   }
   .align-self-lg-baseline {
+    -webkit-align-self: baseline !important;
     -ms-flex-item-align: baseline !important;
     align-self: baseline !important;
   }
   .align-self-lg-stretch {
+    -webkit-align-self: stretch !important;
     -ms-flex-item-align: stretch !important;
     align-self: stretch !important;
   }
@@ -7789,138 +8312,172 @@ button.bg-dark:focus {
 
 @media (min-width: 1200px) {
   .flex-xl-row {
+    -webkit-flex-direction: row !important;
     -ms-flex-direction: row !important;
     flex-direction: row !important;
   }
   .flex-xl-column {
+    -webkit-flex-direction: column !important;
     -ms-flex-direction: column !important;
     flex-direction: column !important;
   }
   .flex-xl-row-reverse {
+    -webkit-flex-direction: row-reverse !important;
     -ms-flex-direction: row-reverse !important;
     flex-direction: row-reverse !important;
   }
   .flex-xl-column-reverse {
+    -webkit-flex-direction: column-reverse !important;
     -ms-flex-direction: column-reverse !important;
     flex-direction: column-reverse !important;
   }
   .flex-xl-wrap {
+    -webkit-flex-wrap: wrap !important;
     -ms-flex-wrap: wrap !important;
     flex-wrap: wrap !important;
   }
   .flex-xl-nowrap {
+    -webkit-flex-wrap: nowrap !important;
     -ms-flex-wrap: nowrap !important;
     flex-wrap: nowrap !important;
   }
   .flex-xl-wrap-reverse {
+    -webkit-flex-wrap: wrap-reverse !important;
     -ms-flex-wrap: wrap-reverse !important;
     flex-wrap: wrap-reverse !important;
   }
   .flex-xl-fill {
+    -webkit-flex: 1 1 auto !important;
     -ms-flex: 1 1 auto !important;
     flex: 1 1 auto !important;
   }
   .flex-xl-grow-0 {
+    -webkit-flex-grow: 0 !important;
     -ms-flex-positive: 0 !important;
     flex-grow: 0 !important;
   }
   .flex-xl-grow-1 {
+    -webkit-flex-grow: 1 !important;
     -ms-flex-positive: 1 !important;
     flex-grow: 1 !important;
   }
   .flex-xl-shrink-0 {
+    -webkit-flex-shrink: 0 !important;
     -ms-flex-negative: 0 !important;
     flex-shrink: 0 !important;
   }
   .flex-xl-shrink-1 {
+    -webkit-flex-shrink: 1 !important;
     -ms-flex-negative: 1 !important;
     flex-shrink: 1 !important;
   }
   .justify-content-xl-start {
+    -webkit-justify-content: flex-start !important;
     -ms-flex-pack: start !important;
     justify-content: flex-start !important;
   }
   .justify-content-xl-end {
+    -webkit-justify-content: flex-end !important;
     -ms-flex-pack: end !important;
     justify-content: flex-end !important;
   }
   .justify-content-xl-center {
+    -webkit-justify-content: center !important;
     -ms-flex-pack: center !important;
     justify-content: center !important;
   }
   .justify-content-xl-between {
+    -webkit-justify-content: space-between !important;
     -ms-flex-pack: justify !important;
     justify-content: space-between !important;
   }
   .justify-content-xl-around {
+    -webkit-justify-content: space-around !important;
     -ms-flex-pack: distribute !important;
     justify-content: space-around !important;
   }
   .align-items-xl-start {
+    -webkit-align-items: flex-start !important;
     -ms-flex-align: start !important;
     align-items: flex-start !important;
   }
   .align-items-xl-end {
+    -webkit-align-items: flex-end !important;
     -ms-flex-align: end !important;
     align-items: flex-end !important;
   }
   .align-items-xl-center {
+    -webkit-align-items: center !important;
     -ms-flex-align: center !important;
     align-items: center !important;
   }
   .align-items-xl-baseline {
+    -webkit-align-items: baseline !important;
     -ms-flex-align: baseline !important;
     align-items: baseline !important;
   }
   .align-items-xl-stretch {
+    -webkit-align-items: stretch !important;
     -ms-flex-align: stretch !important;
     align-items: stretch !important;
   }
   .align-content-xl-start {
+    -webkit-align-content: flex-start !important;
     -ms-flex-line-pack: start !important;
     align-content: flex-start !important;
   }
   .align-content-xl-end {
+    -webkit-align-content: flex-end !important;
     -ms-flex-line-pack: end !important;
     align-content: flex-end !important;
   }
   .align-content-xl-center {
+    -webkit-align-content: center !important;
     -ms-flex-line-pack: center !important;
     align-content: center !important;
   }
   .align-content-xl-between {
+    -webkit-align-content: space-between !important;
     -ms-flex-line-pack: justify !important;
     align-content: space-between !important;
   }
   .align-content-xl-around {
+    -webkit-align-content: space-around !important;
     -ms-flex-line-pack: distribute !important;
     align-content: space-around !important;
   }
   .align-content-xl-stretch {
+    -webkit-align-content: stretch !important;
     -ms-flex-line-pack: stretch !important;
     align-content: stretch !important;
   }
   .align-self-xl-auto {
+    -webkit-align-self: auto !important;
     -ms-flex-item-align: auto !important;
     align-self: auto !important;
   }
   .align-self-xl-start {
+    -webkit-align-self: flex-start !important;
     -ms-flex-item-align: start !important;
     align-self: flex-start !important;
   }
   .align-self-xl-end {
+    -webkit-align-self: flex-end !important;
     -ms-flex-item-align: end !important;
     align-self: flex-end !important;
   }
   .align-self-xl-center {
+    -webkit-align-self: center !important;
     -ms-flex-item-align: center !important;
     align-self: center !important;
   }
   .align-self-xl-baseline {
+    -webkit-align-self: baseline !important;
     -ms-flex-item-align: baseline !important;
     align-self: baseline !important;
   }
   .align-self-xl-stretch {
+    -webkit-align-self: stretch !important;
     -ms-flex-item-align: stretch !important;
     align-self: stretch !important;
   }
@@ -7989,7 +8546,6 @@ button.bg-dark:focus {
 .user-select-all {
   -webkit-user-select: all !important;
   -moz-user-select: all !important;
-  -ms-user-select: all !important;
   user-select: all !important;
 }
 
@@ -10296,6 +10852,311 @@ a.text-dark:hover, a.text-dark:focus {
   }
 }
 
+@-webkit-keyframes flipInX {
+  0% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    transition-timing-function: ease-in;
+    opacity: 0;
+  }
+  40% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
+    transition-timing-function: ease-in;
+  }
+  60% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
+    opacity: 1;
+  }
+  80% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+  }
+  100% {
+    -webkit-transform: perspective(400px);
+    transform: perspective(400px);
+  }
+}
+
+@keyframes flipInX {
+  0% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    transition-timing-function: ease-in;
+    opacity: 0;
+  }
+  40% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
+    transition-timing-function: ease-in;
+  }
+  60% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
+    opacity: 1;
+  }
+  80% {
+    -webkit-transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+  }
+  100% {
+    -webkit-transform: perspective(400px);
+    transform: perspective(400px);
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes shake {
+  0% {
+    -webkit-transform: translate(2px, 1px) rotate(0deg);
+    transform: translate(2px, 1px) rotate(0deg);
+  }
+  10% {
+    -webkit-transform: translate(-1px, -2px) rotate(-2deg);
+    transform: translate(-1px, -2px) rotate(-2deg);
+  }
+  20% {
+    -webkit-transform: translate(-3px, 0) rotate(3deg);
+    transform: translate(-3px, 0) rotate(3deg);
+  }
+  30% {
+    -webkit-transform: translate(0, 2px) rotate(0deg);
+    transform: translate(0, 2px) rotate(0deg);
+  }
+  40% {
+    -webkit-transform: translate(1px, -1px) rotate(1deg);
+    transform: translate(1px, -1px) rotate(1deg);
+  }
+  50% {
+    -webkit-transform: translate(-1px, 2px) rotate(-1deg);
+    transform: translate(-1px, 2px) rotate(-1deg);
+  }
+  60% {
+    -webkit-transform: translate(-3px, 1px) rotate(0deg);
+    transform: translate(-3px, 1px) rotate(0deg);
+  }
+  70% {
+    -webkit-transform: translate(2px, 1px) rotate(-2deg);
+    transform: translate(2px, 1px) rotate(-2deg);
+  }
+  80% {
+    -webkit-transform: translate(-1px, -1px) rotate(4deg);
+    transform: translate(-1px, -1px) rotate(4deg);
+  }
+  90% {
+    -webkit-transform: translate(2px, 2px) rotate(0deg);
+    transform: translate(2px, 2px) rotate(0deg);
+  }
+  100% {
+    -webkit-transform: translate(1px, -2px) rotate(-1deg);
+    transform: translate(1px, -2px) rotate(-1deg);
+  }
+}
+
+@keyframes shake {
+  0% {
+    -webkit-transform: translate(2px, 1px) rotate(0deg);
+    transform: translate(2px, 1px) rotate(0deg);
+  }
+  10% {
+    -webkit-transform: translate(-1px, -2px) rotate(-2deg);
+    transform: translate(-1px, -2px) rotate(-2deg);
+  }
+  20% {
+    -webkit-transform: translate(-3px, 0) rotate(3deg);
+    transform: translate(-3px, 0) rotate(3deg);
+  }
+  30% {
+    -webkit-transform: translate(0, 2px) rotate(0deg);
+    transform: translate(0, 2px) rotate(0deg);
+  }
+  40% {
+    -webkit-transform: translate(1px, -1px) rotate(1deg);
+    transform: translate(1px, -1px) rotate(1deg);
+  }
+  50% {
+    -webkit-transform: translate(-1px, 2px) rotate(-1deg);
+    transform: translate(-1px, 2px) rotate(-1deg);
+  }
+  60% {
+    -webkit-transform: translate(-3px, 1px) rotate(0deg);
+    transform: translate(-3px, 1px) rotate(0deg);
+  }
+  70% {
+    -webkit-transform: translate(2px, 1px) rotate(-2deg);
+    transform: translate(2px, 1px) rotate(-2deg);
+  }
+  80% {
+    -webkit-transform: translate(-1px, -1px) rotate(4deg);
+    transform: translate(-1px, -1px) rotate(4deg);
+  }
+  90% {
+    -webkit-transform: translate(2px, 2px) rotate(0deg);
+    transform: translate(2px, 2px) rotate(0deg);
+  }
+  100% {
+    -webkit-transform: translate(1px, -2px) rotate(-1deg);
+    transform: translate(1px, -2px) rotate(-1deg);
+  }
+}
+
+@-webkit-keyframes wobble {
+  0% {
+    -webkit-transform: none;
+    transform: none;
+  }
+  15% {
+    -webkit-transform: translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg);
+    transform: translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg);
+  }
+  30% {
+    -webkit-transform: translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg);
+    transform: translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg);
+  }
+  45% {
+    -webkit-transform: translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg);
+    transform: translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg);
+  }
+  60% {
+    -webkit-transform: translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg);
+    transform: translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg);
+  }
+  75% {
+    -webkit-transform: translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg);
+    transform: translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg);
+  }
+  100% {
+    -webkit-transform: none;
+    transform: none;
+  }
+}
+
+@keyframes wobble {
+  0% {
+    -webkit-transform: none;
+    transform: none;
+  }
+  15% {
+    -webkit-transform: translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg);
+    transform: translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg);
+  }
+  30% {
+    -webkit-transform: translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg);
+    transform: translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg);
+  }
+  45% {
+    -webkit-transform: translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg);
+    transform: translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg);
+  }
+  60% {
+    -webkit-transform: translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg);
+    transform: translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg);
+  }
+  75% {
+    -webkit-transform: translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg);
+    transform: translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg);
+  }
+  100% {
+    -webkit-transform: none;
+    transform: none;
+  }
+}
+
+.dark-mode :root {
+  --lightblue: #86bad8;
+  --navy: #002c59;
+  --olive: #74c8a3;
+  --lime: #67ffa9;
+  --fuchsia: #f672d8;
+  --maroon: #ed6c9b;
+  --blue: #3f6791;
+  --indigo: #6610f2;
+  --purple: #6f42c1;
+  --pink: #e83e8c;
+  --red: #e74c3c;
+  --orange: #fd7e14;
+  --yellow: #f39c12;
+  --green: #00bc8c;
+  --teal: #20c997;
+  --cyan: #3498db;
+  --white: #fff;
+  --gray: #6c757d;
+  --gray-dark: #343a40;
+  --primary: #3f6791;
+  --secondary: #6c757d;
+  --success: #00bc8c;
+  --info: #3498db;
+  --warning: #f39c12;
+  --danger: #e74c3c;
+  --light: #f8f9fa;
+  --dark: #343a40;
+}
+
+.animation__shake {
+  -webkit-animation: shake 1500ms;
+  animation: shake 1500ms;
+}
+
+.animation__wobble {
+  -webkit-animation: wobble 1500ms;
+  animation: wobble 1500ms;
+}
+
+.preloader {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background-color: #f4f6f9;
+  height: 100vh;
+  width: 100%;
+  transition: height 200ms linear;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 9999;
+}
+
+.dark-mode .preloader {
+  background-color: #454d55 !important;
+  color: #fff;
+}
+
 html.scroll-smooth {
   scroll-behavior: smooth;
 }
@@ -10361,18 +11222,21 @@ body,
 }
 
 .layout-navbar-fixed.sidebar-mini.sidebar-collapse .wrapper .brand-link,
-.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse .wrapper .brand-link {
+.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse .wrapper .brand-link,
+.layout-navbar-fixed.sidebar-mini-xs.sidebar-collapse .wrapper .brand-link {
   height: calc(3.5rem + 1px);
   width: 4.6rem;
 }
 
 .layout-navbar-fixed.sidebar-mini.sidebar-collapse .wrapper .brand-link.text-sm,
-.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse .wrapper .brand-link.text-sm {
+.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse .wrapper .brand-link.text-sm,
+.layout-navbar-fixed.sidebar-mini-xs.sidebar-collapse .wrapper .brand-link.text-sm {
   height: calc(2.93725rem + 1px);
 }
 
 .layout-navbar-fixed.sidebar-mini.sidebar-collapse.text-sm .wrapper .brand-link,
-.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse.text-sm .wrapper .brand-link {
+.layout-navbar-fixed.sidebar-mini-md.sidebar-collapse.text-sm .wrapper .brand-link,
+.layout-navbar-fixed.sidebar-mini-xs.sidebar-collapse.text-sm .wrapper .brand-link {
   height: calc(2.93725rem + 1px);
 }
 
@@ -11356,45 +12220,43 @@ body:not(.layout-fixed).layout-navbar-fixed.text-sm .wrapper .main-sidebar .side
   margin-left: 0;
 }
 
-body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .content-wrapper, body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .content-wrapper::before,
-body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-footer,
-body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-footer::before,
-body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header,
-body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::before {
+body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .content-wrapper, body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .content-wrapper::before,
+body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .main-footer,
+body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .main-footer::before,
+body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .main-header,
+body.sidebar-collapse:not(.sidebar-mini-xs):not(.sidebar-mini-md):not(.sidebar-mini) .main-header::before {
   margin-left: 0;
 }
 
 @media (min-width: 768px) {
-  body:not(.sidebar-mini-md) .content-wrapper,
-  body:not(.sidebar-mini-md) .main-footer,
-  body:not(.sidebar-mini-md) .main-header {
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .content-wrapper,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-footer,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-header {
     transition: margin-left 0.3s ease-in-out;
     margin-left: 250px;
   }
 }
 
 @media (min-width: 768px) and (prefers-reduced-motion: reduce) {
-  body:not(.sidebar-mini-md) .content-wrapper,
-  body:not(.sidebar-mini-md) .main-footer,
-  body:not(.sidebar-mini-md) .main-header {
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .content-wrapper,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-footer,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-header {
     transition: none;
   }
 }
 
 @media (min-width: 768px) {
-  .sidebar-collapse body:not(.sidebar-mini-md) .content-wrapper, .sidebar-collapse
-  body:not(.sidebar-mini-md) .main-footer, .sidebar-collapse
-  body:not(.sidebar-mini-md) .main-header {
+  .sidebar-collapse body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .content-wrapper, .sidebar-collapse
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-footer, .sidebar-collapse
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-header {
     margin-left: 0;
   }
 }
 
 @media (max-width: 991.98px) {
-  body:not(.sidebar-mini-md) .content-wrapper, body:not(.sidebar-mini-md) .content-wrapper::before,
-  body:not(.sidebar-mini-md) .main-footer,
-  body:not(.sidebar-mini-md) .main-footer::before,
-  body:not(.sidebar-mini-md) .main-header,
-  body:not(.sidebar-mini-md) .main-header::before {
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .content-wrapper,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-footer,
+  body:not(.sidebar-mini-md):not(.sidebar-mini-xs):not(.layout-top-nav) .main-header {
     margin-left: 0;
   }
 }
@@ -11425,11 +12287,50 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 }
 
 @media (max-width: 991.98px) {
-  .sidebar-mini-md .content-wrapper, .sidebar-mini-md .content-wrapper::before,
+  .sidebar-mini-md .content-wrapper,
   .sidebar-mini-md .main-footer,
-  .sidebar-mini-md .main-footer::before,
-  .sidebar-mini-md .main-header,
-  .sidebar-mini-md .main-header::before {
+  .sidebar-mini-md .main-header {
+    margin-left: 4.6rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .sidebar-mini-md .content-wrapper,
+  .sidebar-mini-md .main-footer,
+  .sidebar-mini-md .main-header {
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .sidebar-mini-xs .content-wrapper,
+  .sidebar-mini-xs .main-footer,
+  .sidebar-mini-xs .main-header {
+    transition: margin-left 0.3s ease-in-out;
+    margin-left: 250px;
+  }
+}
+
+@media (min-width: 768px) and (prefers-reduced-motion: reduce) {
+  .sidebar-mini-xs .content-wrapper,
+  .sidebar-mini-xs .main-footer,
+  .sidebar-mini-xs .main-header {
+    transition: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .sidebar-collapse .sidebar-mini-xs .content-wrapper, .sidebar-collapse
+  .sidebar-mini-xs .main-footer, .sidebar-collapse
+  .sidebar-mini-xs .main-header {
+    margin-left: 4.6rem;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .sidebar-mini-xs .content-wrapper,
+  .sidebar-mini-xs .main-footer,
+  .sidebar-mini-xs .main-header {
     margin-left: 4.6rem;
   }
 }
@@ -11453,7 +12354,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
 }
 
-.sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md) .main-sidebar, .sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md) .main-sidebar::before {
+.sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs) .main-sidebar, .sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs) .main-sidebar::before {
   box-shadow: none !important;
 }
 
@@ -11475,11 +12376,15 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
 }
 
-:not(.layout-fixed) .main-sidebar {
+body:not(.layout-fixed) .main-sidebar {
   height: inherit;
   min-height: 100%;
   position: absolute;
   top: 0;
+}
+
+body:not(.layout-fixed) .main-sidebar .sidebar {
+  overflow-y: auto;
 }
 
 .layout-fixed .brand-link {
@@ -11489,7 +12394,6 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .layout-fixed .main-sidebar {
   bottom: 0;
   float: none;
-  height: 100vh;
   left: 0;
   position: fixed;
   top: 0;
@@ -11498,13 +12402,33 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .layout-fixed .control-sidebar {
   bottom: 0;
   float: none;
-  height: 100vh;
   position: fixed;
   top: 0;
 }
 
+.layout-fixed .control-sidebar .control-sidebar-content::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.layout-fixed .control-sidebar .control-sidebar-content::-webkit-scrollbar-thumb {
+  background-color: #a9a9a9;
+}
+
+.layout-fixed .control-sidebar .control-sidebar-content::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.layout-fixed .control-sidebar .control-sidebar-content::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
 .layout-fixed .control-sidebar .control-sidebar-content {
   height: calc(100vh - calc(3.5rem + 1px));
+  overflow-y: auto;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: thin;
+  scrollbar-color: #a9a9a9 transparent;
 }
 
 @supports (-webkit-touch-callout: none) {
@@ -11567,6 +12491,338 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .dark-mode {
   background-color: #454d55 !important;
   color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+  background-color: #343a40;
+}
+
+.layout-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+  background-color: #fff;
+}
+
+@media (min-width: 576px) {
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-sm-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+}
+
+@media (min-width: 768px) {
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-md-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+}
+
+@media (min-width: 992px) {
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-lg-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+}
+
+@media (min-width: 1200px) {
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-primary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-primary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-secondary .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-success .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-success .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-info .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-info .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-warning .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-warning .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-danger .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-danger .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-light .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-light .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-dark-dark .brand-link:not([class*="navbar"]) {
+    background-color: #343a40;
+  }
+  .layout-xl-navbar-fixed .dark-mode .wrapper .sidebar-light-dark .brand-link:not([class*="navbar"]) {
+    background-color: #fff;
+  }
 }
 
 .dark-mode .breadcrumb-item.active,
@@ -11677,8 +12933,8 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .navbar-dark .form-control-navbar,
 .navbar-dark .btn-navbar {
-  background-color: rgba(255, 255, 255, 0.2);
-  border: 0;
+  background-color: #343a40;
+  border-color: #6c757d;
 }
 
 .navbar-dark .form-control-navbar::-webkit-input-placeholder {
@@ -11707,15 +12963,15 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .navbar-dark .form-control-navbar:focus,
 .navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
-  background-color: rgba(255, 255, 255, 0.6);
-  border: 0 !important;
-  color: #343a40;
+  background-color: #495057;
+  border-color: #6c757d !important;
+  color: #ced4da;
 }
 
 .navbar-light .form-control-navbar,
 .navbar-light .btn-navbar {
-  background-color: #f2f4f6;
-  border: 0;
+  background-color: #dadfe4;
+  border-color: #ced4da;
 }
 
 .navbar-light .form-control-navbar::-webkit-input-placeholder {
@@ -11744,9 +13000,42 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .navbar-light .form-control-navbar:focus,
 .navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
-  background-color: #e9ecef;
-  border: 0 !important;
-  color: #343a40;
+  background-color: #d3d9df;
+  border-color: #c7ced5 !important;
+  color: #ced4da;
+}
+
+.navbar-light .navbar-search-block .form-control-navbar:focus,
+.navbar-light .navbar-search-block .form-control-navbar:focus + .input-group-append .btn-navbar {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.navbar-search-block {
+  position: absolute;
+  padding: 0 1rem;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  display: none;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  background-color: initial;
+}
+
+.navbar-search-block.navbar-search-open {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.navbar-search-block .input-group {
+  width: 100%;
 }
 
 .brand-link {
@@ -11864,13 +13153,34 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   outline: none;
 }
 
+.sidebar::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+  background-color: #a9a9a9;
+}
+
+.sidebar::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.sidebar::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
 .sidebar {
   height: calc(100% - (3.5rem + 1px));
+  overflow-x: none;
   overflow-y: initial;
   padding-bottom: 0;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: thin;
+  scrollbar-color: #a9a9a9 transparent;
 }
 
 .user-panel {
@@ -11916,7 +13226,9 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 }
 
 .nav-sidebar .nav-item > .nav-link .right {
+  transition: -webkit-transform ease-in-out 0.3s;
   transition: transform ease-in-out 0.3s;
+  transition: transform ease-in-out 0.3s, -webkit-transform ease-in-out 0.3s;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -11950,6 +13262,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .nav-sidebar .menu-open > .nav-link i.right,
 .nav-sidebar .menu-is-opening > .nav-link i.right {
+  -webkit-transform: rotate(-90deg);
   transform: rotate(-90deg);
 }
 
@@ -12004,16 +13317,13 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .nav-sidebar .nav-header {
   font-size: .9rem;
-  padding: 0.5rem;
-}
-
-.nav-sidebar .nav-header:not(:first-of-type) {
-  padding: 1.7rem 1rem .5rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .nav-sidebar .nav-link p {
-  display: inline-block;
+  display: inline;
   margin: 0;
+  white-space: normal;
 }
 
 .sidebar-is-opening .nav-sidebar .nav-link p {
@@ -12103,6 +13413,11 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 [class*="sidebar-light-"] .nav-treeview > .nav-item > .nav-link {
   color: #777;
+}
+
+[class*="sidebar-light-"] .nav-treeview > .nav-item > .nav-link:hover, [class*="sidebar-light-"] .nav-treeview > .nav-item > .nav-link:focus {
+  background-color: rgba(0, 0, 0, 0.1);
+  color: #000;
 }
 
 [class*="sidebar-light-"] .nav-treeview > .nav-item > .nav-link.active, [class*="sidebar-light-"] .nav-treeview > .nav-item > .nav-link.active:hover {
@@ -12503,10 +13818,13 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand) .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand) .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand) .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-compact.nav-sidebar.nav-child-indent:not(.nav-flat) .nav-treeview {
   padding-left: 1rem;
   margin-left: -.5rem;
 }
@@ -12582,43 +13900,55 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-compact.nav-sidebar .nav-treeview .nav-icon {
   margin-left: .4rem;
 }
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-icon {
   margin-left: .85rem;
 }
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-icon {
   margin-left: 1.15rem;
 }
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-icon {
   margin-left: 1.45rem;
 }
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon {
   margin-left: 1.75rem;
 }
 
 .sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar:not(.sidebar-no-expand):hover .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
 .sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
-.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon {
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon,
+.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-sidebar.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-icon {
   margin-left: 2.05rem;
 }
 
@@ -12682,14 +14012,16 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 }
 
 .sidebar-mini .nav-legacy > .nav-item .nav-link .nav-icon,
-.sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon {
+.sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon,
+.sidebar-mini-xs .nav-legacy > .nav-item .nav-link .nav-icon {
   transition: margin-left ease-in-out 0.3s;
-  margin-left: .75rem;
+  margin-left: .6rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .sidebar-mini .nav-legacy > .nav-item .nav-link .nav-icon,
-  .sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon {
+  .sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon,
+  .sidebar-mini-xs .nav-legacy > .nav-item .nav-link .nav-icon {
     transition: none;
   }
 }
@@ -12697,14 +14029,18 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
 .sidebar-mini.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview,
 .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
-.sidebar-mini-md.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview {
+.sidebar-mini-md.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview {
   padding-left: 1rem;
 }
 
 .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
 .sidebar-mini.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
 .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
-.sidebar-mini-md.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
+.sidebar-mini-md.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
   padding-left: 2rem;
   margin-left: -1rem;
 }
@@ -12712,41 +14048,50 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .sidebar-mini.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
 .sidebar-mini.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview,
 .sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
-.sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview {
+.sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview {
   padding-left: .5rem;
 }
 
 .sidebar-mini.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
 .sidebar-mini.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
 .sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
-.sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
+.sidebar-mini-md.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse.text-sm .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse.text-sm .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
   padding-left: 1rem;
   margin-left: -.5rem;
 }
 
 .sidebar-mini.sidebar-collapse .nav-legacy > .nav-item > .nav-link .nav-icon,
-.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item > .nav-link .nav-icon {
+.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-xs.sidebar-collapse .nav-legacy > .nav-item > .nav-link .nav-icon {
   margin-left: .55rem;
 }
 
 .sidebar-mini.sidebar-collapse .nav-legacy > .nav-item > .nav-link.active > .nav-icon,
-.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item > .nav-link.active > .nav-icon {
+.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-xs.sidebar-collapse .nav-legacy > .nav-item > .nav-link.active > .nav-icon {
   margin-left: .36rem;
 }
 
 .sidebar-mini.sidebar-collapse .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
-.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-child-indent .nav-treeview .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .nav-legacy.nav-child-indent .nav-treeview .nav-treeview {
   padding-left: 0;
   margin-left: 0;
 }
 
 .sidebar-mini.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link .nav-icon,
-.sidebar-mini-md.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link .nav-icon {
+.sidebar-mini-md.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-xs.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link .nav-icon {
   margin-left: .75rem;
 }
 
 .sidebar-mini.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link.active > .nav-icon,
-.sidebar-mini-md.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link.active > .nav-icon {
+.sidebar-mini-md.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-xs.sidebar-collapse.text-sm .nav-legacy > .nav-item > .nav-link.active > .nav-icon {
   margin-left: calc(.75rem - 3px);
 }
 
@@ -12803,7 +14148,9 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .nav-collapse-hide-child .menu-open > .nav-treeview,
 .sidebar-mini.sidebar-collapse .main-sidebar:not(.sidebar-no-expand):hover .nav-collapse-hide-child .menu-open > .nav-treeview,
 .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .nav-collapse-hide-child .menu-open > .nav-treeview,
-.sidebar-mini-md.sidebar-collapse .main-sidebar:not(.sidebar-no-expand):hover .nav-collapse-hide-child .menu-open > .nav-treeview {
+.sidebar-mini-md.sidebar-collapse .main-sidebar:not(.sidebar-no-expand):hover .nav-collapse-hide-child .menu-open > .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .nav-collapse-hide-child .menu-open > .nav-treeview,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:not(.sidebar-no-expand):hover .nav-collapse-hide-child .menu-open > .nav-treeview {
   max-height: -webkit-min-content;
   max-height: -moz-min-content;
   max-height: min-content;
@@ -12912,19 +14259,22 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 
 .sidebar .form-inline .input-group {
   width: 100%;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
 }
 
 .sidebar nav .form-inline {
   margin-bottom: .2rem;
 }
 
-.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md).sidebar-collapse .main-sidebar {
+.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs).sidebar-collapse .main-sidebar {
   margin-left: 0;
 }
 
-.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md) .content-wrapper,
-.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md) .main-header,
-.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md) .main-footer {
+.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs) .content-wrapper,
+.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs) .main-header,
+.layout-boxed:not(.sidebar-mini):not(.sidebar-mini-md):not(.sidebar-mini-xs) .main-footer {
   z-index: 9999;
   position: relative;
 }
@@ -13041,6 +14391,311 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   right: .5rem;
 }
 
+.dark-mode .sidebar-dark-primary .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-primary .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-primary .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-primary .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #3f6791;
+}
+
+.dark-mode .sidebar-dark-secondary .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-secondary .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-secondary .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-secondary .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #6c757d;
+}
+
+.dark-mode .sidebar-dark-success .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-success .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-success .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-success .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #00bc8c;
+}
+
+.dark-mode .sidebar-dark-info .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-info .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-info .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-info .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #3498db;
+}
+
+.dark-mode .sidebar-dark-warning .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-warning .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-warning .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-warning .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #f39c12;
+}
+
+.dark-mode .sidebar-dark-danger .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-danger .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-danger .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-danger .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #e74c3c;
+}
+
+.dark-mode .sidebar-dark-light .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-light .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #f8f9fa;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-light .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-light .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #f8f9fa;
+}
+
+.dark-mode .sidebar-dark-dark .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-dark .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-dark .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-dark .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #343a40;
+}
+
+.dark-mode .sidebar-dark-lightblue .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-lightblue .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #86bad8;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-lightblue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-lightblue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #86bad8;
+}
+
+.dark-mode .sidebar-dark-navy .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-navy .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #002c59;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-navy .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-navy .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #002c59;
+}
+
+.dark-mode .sidebar-dark-olive .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-olive .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #74c8a3;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-olive .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-olive .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #74c8a3;
+}
+
+.dark-mode .sidebar-dark-lime .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-lime .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #67ffa9;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-lime .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-lime .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #67ffa9;
+}
+
+.dark-mode .sidebar-dark-fuchsia .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-fuchsia .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #f672d8;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-fuchsia .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-fuchsia .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #f672d8;
+}
+
+.dark-mode .sidebar-dark-maroon .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-maroon .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-maroon .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-maroon .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #ed6c9b;
+}
+
+.dark-mode .sidebar-dark-blue .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-blue .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-blue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-blue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #3f6791;
+}
+
+.dark-mode .sidebar-dark-indigo .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-indigo .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-indigo .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-indigo .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #6610f2;
+}
+
+.dark-mode .sidebar-dark-purple .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-purple .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-purple .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-purple .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #6f42c1;
+}
+
+.dark-mode .sidebar-dark-pink .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-pink .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-pink .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-pink .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #e83e8c;
+}
+
+.dark-mode .sidebar-dark-red .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-red .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-red .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-red .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #e74c3c;
+}
+
+.dark-mode .sidebar-dark-orange .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-orange .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-orange .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-orange .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #fd7e14;
+}
+
+.dark-mode .sidebar-dark-yellow .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-yellow .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-yellow .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-yellow .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #f39c12;
+}
+
+.dark-mode .sidebar-dark-green .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-green .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-green .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-green .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #00bc8c;
+}
+
+.dark-mode .sidebar-dark-teal .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-teal .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #20c997;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-teal .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-teal .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #20c997;
+}
+
+.dark-mode .sidebar-dark-cyan .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-cyan .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-cyan .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-cyan .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #3498db;
+}
+
+.dark-mode .sidebar-dark-white .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-white .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #fff;
+  color: #1f2d3d;
+}
+
+.dark-mode .sidebar-dark-white .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-white .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #fff;
+}
+
+.dark-mode .sidebar-dark-gray .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-gray .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-gray .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-gray .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #6c757d;
+}
+
+.dark-mode .sidebar-dark-gray-dark .nav-sidebar > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-gray-dark .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .sidebar-dark-gray-dark .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.dark-mode .sidebar-light-gray-dark .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #343a40;
+}
+
+.dark-mode [class*="sidebar-light-"] .sidebar a {
+  color: #343a40;
+}
+
+.dark-mode [class*="sidebar-light-"] .sidebar a:hover {
+  text-decoration: none;
+}
+
 .logo-xs,
 .logo-xl {
   opacity: 1;
@@ -13079,7 +14734,6 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   .sidebar-mini .nav-sidebar > .nav-header,
   .sidebar-mini .nav-sidebar .nav-link {
     white-space: nowrap;
-    overflow: hidden;
   }
   .sidebar-mini.sidebar-collapse .d-hidden-mini {
     display: none;
@@ -13094,6 +14748,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
   .sidebar-mini.sidebar-collapse .nav-sidebar .nav-link p {
     width: 0;
+    white-space: nowrap;
   }
   .sidebar-mini.sidebar-collapse .sidebar .user-panel > .info,
   .sidebar-mini.sidebar-collapse .nav-sidebar .nav-link p,
@@ -13181,6 +14836,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   .sidebar-mini.sidebar-collapse .main-sidebar:hover .user-panel > .info, .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .sidebar-form,
   .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .user-panel > .info {
     display: block !important;
+    -webkit-transform: translateZ(0);
     transform: translateZ(0);
   }
   .sidebar-mini.sidebar-collapse .main-sidebar:hover .nav-sidebar > .nav-item > .nav-link > span, .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .nav-sidebar > .nav-item > .nav-link > span {
@@ -13208,7 +14864,6 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   .sidebar-mini-md .nav-sidebar > .nav-header,
   .sidebar-mini-md .nav-sidebar .nav-link {
     white-space: nowrap;
-    overflow: hidden;
   }
   .sidebar-mini-md.sidebar-collapse .d-hidden-mini {
     display: none;
@@ -13223,6 +14878,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
   .sidebar-mini-md.sidebar-collapse .nav-sidebar .nav-link p {
     width: 0;
+    white-space: nowrap;
   }
   .sidebar-mini-md.sidebar-collapse .sidebar .user-panel > .info,
   .sidebar-mini-md.sidebar-collapse .nav-sidebar .nav-link p,
@@ -13310,6 +14966,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   .sidebar-mini-md.sidebar-collapse .main-sidebar:hover .user-panel > .info, .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .sidebar-form,
   .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .user-panel > .info {
     display: block !important;
+    -webkit-transform: translateZ(0);
     transform: translateZ(0);
   }
   .sidebar-mini-md.sidebar-collapse .main-sidebar:hover .nav-sidebar > .nav-item > .nav-link > span, .sidebar-mini-md.sidebar-collapse .main-sidebar.sidebar-focused .nav-sidebar > .nav-item > .nav-link > span {
@@ -13332,80 +14989,35 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
 }
 
-@-webkit-keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+.sidebar-mini-xs .nav-sidebar,
+.sidebar-mini-xs .nav-sidebar > .nav-header,
+.sidebar-mini-xs .nav-sidebar .nav-link {
+  white-space: nowrap;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@-webkit-keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-.sidebar-collapse .main-sidebar.sidebar-focused .nav-header,
-.sidebar-collapse .main-sidebar:hover .nav-header {
-  display: inline-block;
-}
-
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover {
-  width: 4.6rem;
-}
-
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-header,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-header {
+.sidebar-mini-xs.sidebar-collapse .d-hidden-mini {
   display: none;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .brand-link,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .brand-link {
-  width: 4.6rem !important;
+.sidebar-mini-xs.sidebar-collapse .content-wrapper,
+.sidebar-mini-xs.sidebar-collapse .main-footer,
+.sidebar-mini-xs.sidebar-collapse .main-header {
+  margin-left: 4.6rem !important;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel .image,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .user-panel .image {
-  float: none !important;
+.sidebar-mini-xs.sidebar-collapse .nav-sidebar .nav-header {
+  display: none;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xs,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .logo-xs {
-  -webkit-animation-name: fadeIn;
-  animation-name: fadeIn;
-  -webkit-animation-duration: 0.3s;
-  animation-duration: 0.3s;
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-  visibility: visible;
+.sidebar-mini-xs.sidebar-collapse .nav-sidebar .nav-link p {
+  width: 0;
+  white-space: nowrap;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xl,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .logo-xl {
+.sidebar-mini-xs.sidebar-collapse .sidebar .user-panel > .info,
+.sidebar-mini-xs.sidebar-collapse .nav-sidebar .nav-link p,
+.sidebar-mini-xs.sidebar-collapse .brand-text {
+  margin-left: -10px;
   -webkit-animation-name: fadeOut;
   animation-name: fadeOut;
   -webkit-animation-duration: 0.3s;
@@ -13415,17 +15027,510 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   visibility: hidden;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar.nav-child-indent .nav-treeview,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-sidebar.nav-child-indent .nav-treeview {
+.sidebar-mini-xs.sidebar-collapse .logo-xl {
+  -webkit-animation-name: fadeOut;
+  animation-name: fadeOut;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: hidden;
+}
+
+.sidebar-mini-xs.sidebar-collapse .logo-xs {
+  display: inline-block;
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: visible;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar {
+  overflow-x: hidden;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar, .sidebar-mini-xs.sidebar-collapse .main-sidebar::before {
+  margin-left: 0;
+  width: 4.6rem;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar .user-panel .image {
+  float: none;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused {
+  width: 250px;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .brand-link, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .brand-link {
+  width: 250px;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .user-panel, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .user-panel {
+  text-align: left;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .user-panel .image, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .user-panel .image {
+  float: left;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .user-panel > .info,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .nav-sidebar .nav-link p,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .brand-text,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .logo-xl, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .user-panel > .info,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .nav-sidebar .nav-link p,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .brand-text,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .logo-xl {
+  display: inline-block;
+  margin-left: 0;
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: visible;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .logo-xs, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .logo-xs {
+  -webkit-animation-name: fadeOut;
+  animation-name: fadeOut;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: hidden;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .brand-image, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .brand-image {
+  margin-right: .5rem;
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .sidebar-form,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .user-panel > .info, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .sidebar-form,
+.sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .user-panel > .info {
+  display: block !important;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+
+.sidebar-mini-xs.sidebar-collapse .main-sidebar:hover .nav-sidebar > .nav-item > .nav-link > span, .sidebar-mini-xs.sidebar-collapse .main-sidebar.sidebar-focused .nav-sidebar > .nav-item > .nav-link > span {
+  display: inline-block !important;
+}
+
+.sidebar-mini-xs.sidebar-collapse .visible-sidebar-mini {
+  display: block !important;
+}
+
+.sidebar-mini-xs.sidebar-collapse.layout-fixed .main-sidebar:hover .brand-link {
+  width: 250px;
+}
+
+.sidebar-mini-xs.sidebar-collapse.layout-fixed .brand-link {
+  width: 4.6rem;
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 1rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 2rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 3rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 4rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 5rem);
+}
+
+.sidebar-mini .main-sidebar .nav-legacy .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy .nav-link {
+  width: 250px;
+}
+
+.sidebar-mini .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-link {
+  width: calc(250px - 1rem);
+}
+
+.sidebar-mini .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 1rem);
+}
+
+.sidebar-mini .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 2rem);
+}
+
+.sidebar-mini .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 3rem);
+}
+
+.sidebar-mini .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 4rem);
+}
+
+.sidebar-mini .main-sidebar .nav-flat .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat .nav-link {
+  width: 250px;
+}
+
+.sidebar-mini .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-link {
+  width: calc(250px);
+}
+
+.sidebar-mini .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem);
+}
+
+.sidebar-mini .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 2);
+}
+
+.sidebar-mini .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 3);
+}
+
+.sidebar-mini .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 4);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - .5rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 1rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 1.5rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 2rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 0.5rem * 2 - 2.5rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-link {
+  width: 250px;
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link {
+  width: calc(250px - .5rem);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 2);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 3);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 4);
+}
+
+.sidebar-mini .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-md .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 5);
+}
+
+.sidebar-mini .main-sidebar .nav-link,
+.sidebar-mini-md .main-sidebar .nav-link,
+.sidebar-mini-xs .main-sidebar .nav-link {
+  width: calc(250px - 0.5rem * 2);
+  transition: width ease-in-out 0.3s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-mini .main-sidebar .nav-link,
+  .sidebar-mini-md .main-sidebar .nav-link,
+  .sidebar-mini-xs .main-sidebar .nav-link {
+    transition: none;
+  }
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .nav-sidebar .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar .nav-sidebar .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar .nav-sidebar .nav-link {
+  width: 3.6rem;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .nav-sidebar.nav-flat .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar .nav-sidebar.nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar .nav-sidebar.nav-flat .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar .nav-sidebar.nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar .nav-sidebar.nav-flat .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar .nav-sidebar.nav-legacy .nav-link {
+  width: 4.6rem;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-treeview, .sidebar-collapse.sidebar-mini-md .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-treeview, .sidebar-collapse.sidebar-mini-xs .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-treeview {
+  padding-left: 0 !important;
+  margin-left: 0 !important;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar .nav-sidebar.nav-child-indent.nav-compact .nav-link {
+  width: calc(4.6rem - 0.5rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-link {
+  width: calc(250px - 0.5rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-header, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-header, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-header, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-header, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-header, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-header {
+  display: inline-block;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent .nav-link {
+  width: calc(250px - 0.5rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy .nav-link {
+  width: 250px;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-link {
+  width: calc(250px - 1rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 1rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 2rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 3rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-legacy.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - 1rem - 4rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat .nav-link {
+  width: 250px;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-link {
+  width: calc(250px);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 3);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-flat.nav-child-indent .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .2rem * 4);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-compact .nav-link {
+  width: calc(250px - 0.5rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-link {
+  width: 250px;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-link {
+  width: calc(250px - .5rem);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 2);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 3);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 4);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .nav-child-indent.nav-legacy.nav-compact .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-treeview .nav-link {
+  width: calc(250px - .5rem * 5);
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini .main-sidebar:hover .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .sidebar::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-thumb, .sidebar-collapse.sidebar-mini .main-sidebar:hover .sidebar::-webkit-scrollbar-thumb, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-thumb, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .sidebar::-webkit-scrollbar-thumb, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-thumb, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .sidebar::-webkit-scrollbar-thumb {
+  background-color: #a9a9a9;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-track, .sidebar-collapse.sidebar-mini .main-sidebar:hover .sidebar::-webkit-scrollbar-track, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-track, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .sidebar::-webkit-scrollbar-track, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-track, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .sidebar::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-corner, .sidebar-collapse.sidebar-mini .main-sidebar:hover .sidebar::-webkit-scrollbar-corner, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-corner, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .sidebar::-webkit-scrollbar-corner, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .sidebar::-webkit-scrollbar-corner, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .sidebar::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar.sidebar-focused .sidebar, .sidebar-collapse.sidebar-mini .main-sidebar:hover .sidebar, .sidebar-collapse.sidebar-mini-md .main-sidebar.sidebar-focused .sidebar, .sidebar-collapse.sidebar-mini-md .main-sidebar:hover .sidebar, .sidebar-collapse.sidebar-mini-xs .main-sidebar.sidebar-focused .sidebar, .sidebar-collapse.sidebar-mini-xs .main-sidebar:hover .sidebar {
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: thin;
+  scrollbar-color: #a9a9a9 transparent;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-md .main-sidebar .sidebar::-webkit-scrollbar, .sidebar-collapse.sidebar-mini-xs .main-sidebar .sidebar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.sidebar-collapse.sidebar-mini .main-sidebar .sidebar, .sidebar-collapse.sidebar-mini-md .main-sidebar .sidebar, .sidebar-collapse.sidebar-mini-xs .main-sidebar .sidebar {
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: none;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover {
+  width: 4.6rem;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .nav-header,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .nav-header, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .nav-header,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .nav-header, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .nav-header,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .nav-header {
+  display: none;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .brand-link,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .brand-link, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .brand-link,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .brand-link, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .brand-link,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .brand-link {
+  width: 4.6rem !important;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel .image,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .user-panel .image, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel .image,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .user-panel .image, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel .image,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .user-panel .image {
+  float: none !important;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xs,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .logo-xs, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xs,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .logo-xs, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xs,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .logo-xs {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: visible;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xl,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .logo-xl, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xl,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .logo-xl, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .logo-xl,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .logo-xl {
+  -webkit-animation-name: fadeOut;
+  animation-name: fadeOut;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: hidden;
+}
+
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar.nav-child-indent .nav-treeview,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .nav-sidebar.nav-child-indent .nav-treeview, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar.nav-child-indent .nav-treeview,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .nav-sidebar.nav-child-indent .nav-treeview, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar.nav-child-indent .nav-treeview,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .nav-sidebar.nav-child-indent .nav-treeview {
   padding-left: 0;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .brand-text,
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel > .info,
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar .nav-link p,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .brand-text,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .user-panel > .info,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-sidebar .nav-link p {
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .brand-text,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel > .info,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar .nav-link p,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .brand-text,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .user-panel > .info,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .nav-sidebar .nav-link p, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .brand-text,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel > .info,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar .nav-link p,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .brand-text,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .user-panel > .info,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .nav-sidebar .nav-link p, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .brand-text,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .user-panel > .info,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar .nav-link p,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .brand-text,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .user-panel > .info,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .nav-sidebar .nav-link p {
   margin-left: -10px;
   -webkit-animation-name: fadeOut;
   animation-name: fadeOut;
@@ -13437,8 +15542,10 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   width: 0;
 }
 
-.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar > .nav-item .nav-icon,
-.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-sidebar > .nav-item .nav-icon {
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar > .nav-item .nav-icon,
+.sidebar-collapse.sidebar-mini .sidebar-no-expand.main-sidebar:hover .nav-sidebar > .nav-item .nav-icon, .sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar > .nav-item .nav-icon,
+.sidebar-collapse.sidebar-mini-md .sidebar-no-expand.main-sidebar:hover .nav-sidebar > .nav-item .nav-icon, .sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar.sidebar-focused .nav-sidebar > .nav-item .nav-icon,
+.sidebar-collapse.sidebar-mini-xs .sidebar-no-expand.main-sidebar:hover .nav-sidebar > .nav-item .nav-icon {
   margin-right: 0;
 }
 
@@ -13740,50 +15847,6 @@ body.text-sm .control-sidebar {
   backface-visibility: visible !important;
 }
 
-@-webkit-keyframes flipInX {
-  0% {
-    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
-    transition-timing-function: ease-in;
-    opacity: 0;
-  }
-  40% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
-    transition-timing-function: ease-in;
-  }
-  60% {
-    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
-    opacity: 1;
-  }
-  80% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
-  }
-  100% {
-    transform: perspective(400px);
-  }
-}
-
-@keyframes flipInX {
-  0% {
-    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
-    transition-timing-function: ease-in;
-    opacity: 0;
-  }
-  40% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
-    transition-timing-function: ease-in;
-  }
-  60% {
-    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
-    opacity: 1;
-  }
-  80% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
-  }
-  100% {
-    transform: perspective(400px);
-  }
-}
-
 .navbar-custom-menu > .navbar-nav > li {
   position: relative;
 }
@@ -14014,6 +16077,7 @@ body.text-sm .control-sidebar {
 }
 
 .navbar-no-expand {
+  -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
@@ -14038,102 +16102,2827 @@ body.text-sm .control-sidebar {
 
 .navbar-primary {
   background-color: #007bff;
+  color: #fff;
+}
+
+.navbar-primary.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar,
+.navbar-primary.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #0071eb;
+  border-color: #0065d1;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-primary.navbar-light .form-control-navbar:focus,
+.navbar-primary.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #006fe6;
+  border-color: #0065d1 !important;
+  color: #343a40;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar,
+.navbar-primary.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1486ff;
+  border-color: #2e93ff;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-primary.navbar-dark .form-control-navbar:focus,
+.navbar-primary.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1a88ff;
+  border-color: #2e93ff !important;
+  color: #fff;
 }
 
 .navbar-secondary {
   background-color: #6c757d;
+  color: #fff;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar,
+.navbar-secondary.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #636b72;
+  border-color: #575e64;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-light .form-control-navbar:focus,
+.navbar-secondary.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #60686f;
+  border-color: #575e64 !important;
+  color: #343a40;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar,
+.navbar-secondary.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #757f88;
+  border-color: #838c94;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-secondary.navbar-dark .form-control-navbar:focus,
+.navbar-secondary.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #78828a;
+  border-color: #838c94 !important;
+  color: #fff;
 }
 
 .navbar-success {
   background-color: #28a745;
+  color: #fff;
+}
+
+.navbar-success.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar,
+.navbar-success.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #24973e;
+  border-color: #1f8236;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-success.navbar-light .form-control-navbar:focus,
+.navbar-success.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #23923d;
+  border-color: #1f8236 !important;
+  color: #343a40;
+}
+
+.navbar-success.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar,
+.navbar-success.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #2cb74c;
+  border-color: #31cc54;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-success.navbar-dark .form-control-navbar:focus,
+.navbar-success.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #2dbc4e;
+  border-color: #31cc54 !important;
+  color: #fff;
 }
 
 .navbar-info {
   background-color: #17a2b8;
+  color: #fff;
+}
+
+.navbar-info.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar,
+.navbar-info.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1592a6;
+  border-color: #127e8f;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-info.navbar-light .form-control-navbar:focus,
+.navbar-info.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #148ea1;
+  border-color: #127e8f !important;
+  color: #343a40;
+}
+
+.navbar-info.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar,
+.navbar-info.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #19b2ca;
+  border-color: #1cc6e1;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-info.navbar-dark .form-control-navbar:focus,
+.navbar-info.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1ab6cf;
+  border-color: #1cc6e1 !important;
+  color: #fff;
 }
 
 .navbar-warning {
   background-color: #ffc107;
+  color: #1f2d3d;
+}
+
+.navbar-warning.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar,
+.navbar-warning.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f2b500;
+  border-color: #d8a200;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-warning.navbar-light .form-control-navbar:focus,
+.navbar-warning.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #edb100;
+  border-color: #d8a200 !important;
+  color: #343a40;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar,
+.navbar-warning.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ffc61b;
+  border-color: #ffcc35;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-warning.navbar-dark .form-control-navbar:focus,
+.navbar-warning.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #ffc721;
+  border-color: #ffcc35 !important;
+  color: #fff;
 }
 
 .navbar-danger {
   background-color: #dc3545;
+  color: #fff;
+}
+
+.navbar-danger.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar,
+.navbar-danger.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #d72536;
+  border-color: #c22231;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-danger.navbar-light .form-control-navbar:focus,
+.navbar-danger.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #d32535;
+  border-color: #c22231 !important;
+  color: #343a40;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar,
+.navbar-danger.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #df4655;
+  border-color: #e35c69;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-danger.navbar-dark .form-control-navbar:focus,
+.navbar-danger.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e04b59;
+  border-color: #e35c69 !important;
+  color: #fff;
 }
 
 .navbar-lightblue {
   background-color: #3c8dbc;
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar,
+.navbar-lightblue.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #3781ad;
+  border-color: #317399;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-light .form-control-navbar:focus,
+.navbar-lightblue.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #367fa9;
+  border-color: #317399 !important;
+  color: #343a40;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar,
+.navbar-lightblue.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #4897c5;
+  border-color: #5ba2cb;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-lightblue.navbar-dark .form-control-navbar:focus,
+.navbar-lightblue.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4c99c6;
+  border-color: #5ba2cb !important;
+  color: #fff;
 }
 
 .navbar-navy {
   background-color: #001f3f;
+  color: #fff;
+}
+
+.navbar-navy.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar,
+.navbar-navy.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00152b;
+  border-color: #000811;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-navy.navbar-light .form-control-navbar:focus,
+.navbar-navy.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #001226;
+  border-color: #000811 !important;
+  color: #343a40;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar,
+.navbar-navy.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #002953;
+  border-color: #00366d;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-navy.navbar-dark .form-control-navbar:focus,
+.navbar-navy.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #002c59;
+  border-color: #00366d !important;
+  color: #fff;
 }
 
 .navbar-olive {
   background-color: #3d9970;
+  color: #fff;
+}
+
+.navbar-olive.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar,
+.navbar-olive.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #378a65;
+  border-color: #307858;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-olive.navbar-light .form-control-navbar:focus,
+.navbar-olive.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #368763;
+  border-color: #307858 !important;
+  color: #343a40;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar,
+.navbar-olive.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #43a87b;
+  border-color: #4cb888;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-olive.navbar-dark .form-control-navbar:focus,
+.navbar-olive.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #44ab7d;
+  border-color: #4cb888 !important;
+  color: #fff;
 }
 
 .navbar-lime {
   background-color: #01ff70;
+  color: #1f2d3d;
+}
+
+.navbar-lime.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar,
+.navbar-lime.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00ec67;
+  border-color: #00d25c;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-lime.navbar-light .form-control-navbar:focus,
+.navbar-lime.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #00e765;
+  border-color: #00d25c !important;
+  color: #343a40;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar,
+.navbar-lime.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #15ff7b;
+  border-color: #2fff8a;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-lime.navbar-dark .form-control-navbar:focus,
+.navbar-lime.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1bff7e;
+  border-color: #2fff8a !important;
+  color: #fff;
 }
 
 .navbar-fuchsia {
   background-color: #f012be;
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar,
+.navbar-fuchsia.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #df0eb0;
+  border-color: #c70d9d;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-light .form-control-navbar:focus,
+.navbar-fuchsia.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #db0ead;
+  border-color: #c70d9d !important;
+  color: #343a40;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar,
+.navbar-fuchsia.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f125c3;
+  border-color: #f33dca;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus,
+.navbar-fuchsia.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f22ac5;
+  border-color: #f33dca !important;
+  color: #fff;
 }
 
 .navbar-maroon {
   background-color: #d81b60;
+  color: #fff;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar,
+.navbar-maroon.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #c61958;
+  border-color: #af164e;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-light .form-control-navbar:focus,
+.navbar-maroon.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #c11856;
+  border-color: #af164e !important;
+  color: #343a40;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar,
+.navbar-maroon.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e4246a;
+  border-color: #e63a79;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-maroon.navbar-dark .form-control-navbar:focus,
+.navbar-maroon.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e4286d;
+  border-color: #e63a79 !important;
+  color: #fff;
 }
 
 .navbar-blue {
   background-color: #007bff;
+  color: #fff;
+}
+
+.navbar-blue.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar,
+.navbar-blue.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #0071eb;
+  border-color: #0065d1;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-blue.navbar-light .form-control-navbar:focus,
+.navbar-blue.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #006fe6;
+  border-color: #0065d1 !important;
+  color: #343a40;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar,
+.navbar-blue.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1486ff;
+  border-color: #2e93ff;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-blue.navbar-dark .form-control-navbar:focus,
+.navbar-blue.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1a88ff;
+  border-color: #2e93ff !important;
+  color: #fff;
 }
 
 .navbar-indigo {
   background-color: #6610f2;
+  color: #fff;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar,
+.navbar-indigo.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #5d0ce1;
+  border-color: #530bc9;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-light .form-control-navbar:focus,
+.navbar-indigo.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #5b0cdd;
+  border-color: #530bc9 !important;
+  color: #343a40;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar,
+.navbar-indigo.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #7223f3;
+  border-color: #823cf4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-indigo.navbar-dark .form-control-navbar:focus,
+.navbar-indigo.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #7528f3;
+  border-color: #823cf4 !important;
+  color: #fff;
 }
 
 .navbar-purple {
   background-color: #6f42c1;
+  color: #fff;
+}
+
+.navbar-purple.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar,
+.navbar-purple.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #663bb4;
+  border-color: #5b35a0;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-purple.navbar-light .form-control-navbar:focus,
+.navbar-purple.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #643ab0;
+  border-color: #5b35a0 !important;
+  color: #343a40;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar,
+.navbar-purple.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #7b51c6;
+  border-color: #8965cc;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-purple.navbar-dark .form-control-navbar:focus,
+.navbar-purple.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #7e55c7;
+  border-color: #8965cc !important;
+  color: #fff;
 }
 
 .navbar-pink {
   background-color: #e83e8c;
+  color: #fff;
+}
+
+.navbar-pink.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar,
+.navbar-pink.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e62c81;
+  border-color: #de1a74;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-pink.navbar-light .form-control-navbar:focus,
+.navbar-pink.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e5277e;
+  border-color: #de1a74 !important;
+  color: #343a40;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar,
+.navbar-pink.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ea5097;
+  border-color: #ed67a4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-pink.navbar-dark .form-control-navbar:focus,
+.navbar-pink.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #eb559a;
+  border-color: #ed67a4 !important;
+  color: #fff;
 }
 
 .navbar-red {
   background-color: #dc3545;
+  color: #fff;
+}
+
+.navbar-red.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar,
+.navbar-red.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #d72536;
+  border-color: #c22231;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-red.navbar-light .form-control-navbar:focus,
+.navbar-red.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #d32535;
+  border-color: #c22231 !important;
+  color: #343a40;
+}
+
+.navbar-red.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar,
+.navbar-red.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #df4655;
+  border-color: #e35c69;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-red.navbar-dark .form-control-navbar:focus,
+.navbar-red.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e04b59;
+  border-color: #e35c69 !important;
+  color: #fff;
 }
 
 .navbar-orange {
   background-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.navbar-orange.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar,
+.navbar-orange.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #fa7302;
+  border-color: #e16702;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-orange.navbar-light .form-control-navbar:focus,
+.navbar-orange.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f57102;
+  border-color: #e16702 !important;
+  color: #343a40;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar,
+.navbar-orange.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #fd8928;
+  border-color: #fd9742;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-orange.navbar-dark .form-control-navbar:focus,
+.navbar-orange.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #fd8c2d;
+  border-color: #fd9742 !important;
+  color: #fff;
 }
 
 .navbar-yellow {
   background-color: #ffc107;
+  color: #1f2d3d;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar,
+.navbar-yellow.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f2b500;
+  border-color: #d8a200;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-light .form-control-navbar:focus,
+.navbar-yellow.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #edb100;
+  border-color: #d8a200 !important;
+  color: #343a40;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar,
+.navbar-yellow.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ffc61b;
+  border-color: #ffcc35;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-yellow.navbar-dark .form-control-navbar:focus,
+.navbar-yellow.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #ffc721;
+  border-color: #ffcc35 !important;
+  color: #fff;
 }
 
 .navbar-green {
   background-color: #28a745;
+  color: #fff;
+}
+
+.navbar-green.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar,
+.navbar-green.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #24973e;
+  border-color: #1f8236;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-green.navbar-light .form-control-navbar:focus,
+.navbar-green.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #23923d;
+  border-color: #1f8236 !important;
+  color: #343a40;
+}
+
+.navbar-green.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar,
+.navbar-green.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #2cb74c;
+  border-color: #31cc54;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-green.navbar-dark .form-control-navbar:focus,
+.navbar-green.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #2dbc4e;
+  border-color: #31cc54 !important;
+  color: #fff;
 }
 
 .navbar-teal {
   background-color: #20c997;
+  color: #fff;
+}
+
+.navbar-teal.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar,
+.navbar-teal.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1db78a;
+  border-color: #1aa179;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-teal.navbar-light .form-control-navbar:focus,
+.navbar-teal.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1cb386;
+  border-color: #1aa179 !important;
+  color: #343a40;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar,
+.navbar-teal.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #23dba4;
+  border-color: #38dfae;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-teal.navbar-dark .form-control-navbar:focus,
+.navbar-teal.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #26dca6;
+  border-color: #38dfae !important;
+  color: #fff;
 }
 
 .navbar-cyan {
   background-color: #17a2b8;
+  color: #fff;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar,
+.navbar-cyan.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1592a6;
+  border-color: #127e8f;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-light .form-control-navbar:focus,
+.navbar-cyan.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #148ea1;
+  border-color: #127e8f !important;
+  color: #343a40;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar,
+.navbar-cyan.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #19b2ca;
+  border-color: #1cc6e1;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-cyan.navbar-dark .form-control-navbar:focus,
+.navbar-cyan.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1ab6cf;
+  border-color: #1cc6e1 !important;
+  color: #fff;
 }
 
 .navbar-white {
   background-color: #fff;
+  color: #1f2d3d;
+}
+
+.navbar-white.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar,
+.navbar-white.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: whitesmoke;
+  border-color: #e8e8e8;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-white.navbar-light .form-control-navbar:focus,
+.navbar-white.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f2f2f2;
+  border-color: #e8e8e8 !important;
+  color: #343a40;
+}
+
+.navbar-white.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar,
+.navbar-white.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: white;
+  border-color: white;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-white.navbar-dark .form-control-navbar:focus,
+.navbar-white.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: white;
+  border-color: white !important;
+  color: #fff;
 }
 
 .navbar-gray {
   background-color: #6c757d;
+  color: #fff;
+}
+
+.navbar-gray.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar,
+.navbar-gray.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #636b72;
+  border-color: #575e64;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-gray.navbar-light .form-control-navbar:focus,
+.navbar-gray.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #60686f;
+  border-color: #575e64 !important;
+  color: #343a40;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar,
+.navbar-gray.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #757f88;
+  border-color: #838c94;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-gray.navbar-dark .form-control-navbar:focus,
+.navbar-gray.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #78828a;
+  border-color: #838c94 !important;
+  color: #fff;
 }
 
 .navbar-gray-dark {
   background-color: #343a40;
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar,
+.navbar-gray-dark.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #2b3035;
+  border-color: #1f2327;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-light .form-control-navbar:focus,
+.navbar-gray-dark.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #292d32;
+  border-color: #1f2327 !important;
+  color: #343a40;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar,
+.navbar-gray-dark.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #3d444b;
+  border-color: #495159;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus,
+.navbar-gray-dark.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #3f474e;
+  border-color: #495159 !important;
+  color: #fff;
 }
 
 .dark-mode .nav-pills .nav-link {
@@ -14177,17 +18966,2855 @@ body.text-sm .control-sidebar {
   border-color: #56606a #56606a #56606a transparent;
 }
 
+.dark-mode .navbar-light {
+  background-color: #f8f9fa;
+}
+
+.dark-mode .navbar-dark {
+  background-color: #343a40;
+  border-color: #4b545c;
+}
+
+.dark-mode .navbar-primary {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar,
+.dark-mode .navbar-primary.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #395d83;
+  border-color: #315071;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-primary.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #375a7f;
+  border-color: #315071 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar,
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #45719f;
+  border-color: #4d7eb1;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-primary.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4774a3;
+  border-color: #4d7eb1 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar,
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #636b72;
+  border-color: #575e64;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-secondary.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #60686f;
+  border-color: #575e64 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar,
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #757f88;
+  border-color: #838c94;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-secondary.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #78828a;
+  border-color: #838c94 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-success {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar,
+.dark-mode .navbar-success.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00a87d;
+  border-color: #008e6a;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-success.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #00a379;
+  border-color: #008e6a !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar,
+.dark-mode .navbar-success.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00d09b;
+  border-color: #00eaae;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-success.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #00d69f;
+  border-color: #00eaae !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-info {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar,
+.dark-mode .navbar-info.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #268fd5;
+  border-color: #2280bf;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-info.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #258cd1;
+  border-color: #2280bf !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar,
+.dark-mode .navbar-info.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #45a1de;
+  border-color: #5bace2;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-info.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4aa3df;
+  border-color: #5bace2 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-warning {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar,
+.dark-mode .navbar-warning.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e5910c;
+  border-color: #cd820a;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-warning.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e08e0b;
+  border-color: #cd820a !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar,
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f4a425;
+  border-color: #f5ae3e;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-warning.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f4a62a;
+  border-color: #f5ae3e !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-danger {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar,
+.dark-mode .navbar-danger.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e53b2a;
+  border-color: #da2d1b;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-danger.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e43725;
+  border-color: #da2d1b !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar,
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e95d4e;
+  border-color: #ec7265;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-danger.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #ea6153;
+  border-color: #ec7265 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue {
+  background-color: #86bad8;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar,
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #76b1d3;
+  border-color: #63a6cd;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-lightblue.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #72afd2;
+  border-color: #63a6cd !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar,
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #95c3dd;
+  border-color: #a9cee3;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-lightblue.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #99c5de;
+  border-color: #a9cee3 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-navy {
+  background-color: #002c59;
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar,
+.dark-mode .navbar-navy.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #002244;
+  border-color: #00152b;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-navy.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #001f3f;
+  border-color: #00152b !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar,
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00366d;
+  border-color: #004286;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-navy.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #003872;
+  border-color: #004286 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-olive {
+  background-color: #74c8a3;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar,
+.dark-mode .navbar-olive.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #66c299;
+  border-color: #53bb8d;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-olive.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #62c096;
+  border-color: #53bb8d !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar,
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #83ceac;
+  border-color: #95d5b8;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-olive.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #87cfaf;
+  border-color: #95d5b8 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-lime {
+  background-color: #67ffa9;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar,
+.dark-mode .navbar-lime.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #53ff9e;
+  border-color: #39ff90;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-lime.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4eff9b;
+  border-color: #39ff90 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar,
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #7bffb5;
+  border-color: #95ffc3;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-lime.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #81ffb8;
+  border-color: #95ffc3 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia {
+  background-color: #f672d8;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar,
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f55fd3;
+  border-color: #f347cc;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-fuchsia.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f55ad2;
+  border-color: #f347cc !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar,
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f785de;
+  border-color: #f99de4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-fuchsia.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f88adf;
+  border-color: #f99de4 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon {
+  background-color: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar,
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ea5a8f;
+  border-color: #e8447f;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-maroon.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #ea568c;
+  border-color: #e8447f !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar,
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ef7ea8;
+  border-color: #f295b7;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-maroon.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f083ab;
+  border-color: #f295b7 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-blue {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar,
+.dark-mode .navbar-blue.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #395d83;
+  border-color: #315071;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-blue.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #375a7f;
+  border-color: #315071 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar,
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #45719f;
+  border-color: #4d7eb1;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-blue.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4774a3;
+  border-color: #4d7eb1 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo {
+  background-color: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar,
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #5d0ce1;
+  border-color: #530bc9;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-indigo.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #5b0cdd;
+  border-color: #530bc9 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar,
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #7223f3;
+  border-color: #823cf4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-indigo.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #7528f3;
+  border-color: #823cf4 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-purple {
+  background-color: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar,
+.dark-mode .navbar-purple.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #663bb4;
+  border-color: #5b35a0;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-purple.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #643ab0;
+  border-color: #5b35a0 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar,
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #7b51c6;
+  border-color: #8965cc;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-purple.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #7e55c7;
+  border-color: #8965cc !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-pink {
+  background-color: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar,
+.dark-mode .navbar-pink.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e62c81;
+  border-color: #de1a74;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-pink.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e5277e;
+  border-color: #de1a74 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar,
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #ea5097;
+  border-color: #ed67a4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-pink.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #eb559a;
+  border-color: #ed67a4 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-red {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar,
+.dark-mode .navbar-red.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e53b2a;
+  border-color: #da2d1b;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-red.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e43725;
+  border-color: #da2d1b !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar,
+.dark-mode .navbar-red.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e95d4e;
+  border-color: #ec7265;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-red.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #ea6153;
+  border-color: #ec7265 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-orange {
+  background-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar,
+.dark-mode .navbar-orange.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #fa7302;
+  border-color: #e16702;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-orange.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f57102;
+  border-color: #e16702 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar,
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #fd8928;
+  border-color: #fd9742;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-orange.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #fd8c2d;
+  border-color: #fd9742 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar,
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #e5910c;
+  border-color: #cd820a;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-yellow.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #e08e0b;
+  border-color: #cd820a !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar,
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #f4a425;
+  border-color: #f5ae3e;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-yellow.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f4a62a;
+  border-color: #f5ae3e !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-green {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar,
+.dark-mode .navbar-green.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00a87d;
+  border-color: #008e6a;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-green.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #00a379;
+  border-color: #008e6a !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar,
+.dark-mode .navbar-green.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #00d09b;
+  border-color: #00eaae;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-green.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #00d69f;
+  border-color: #00eaae !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-teal {
+  background-color: #20c997;
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar,
+.dark-mode .navbar-teal.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #1db78a;
+  border-color: #1aa179;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-teal.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #1cb386;
+  border-color: #1aa179 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar,
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #23dba4;
+  border-color: #38dfae;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-teal.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #26dca6;
+  border-color: #38dfae !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar,
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #268fd5;
+  border-color: #2280bf;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-cyan.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #258cd1;
+  border-color: #2280bf !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar,
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #45a1de;
+  border-color: #5bace2;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-cyan.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #4aa3df;
+  border-color: #5bace2 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-white {
+  background-color: #fff;
+  color: #1f2d3d;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar,
+.dark-mode .navbar-white.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: whitesmoke;
+  border-color: #e8e8e8;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-white.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #f2f2f2;
+  border-color: #e8e8e8 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar,
+.dark-mode .navbar-white.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: white;
+  border-color: white;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-white.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: white;
+  border-color: white !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-gray {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar,
+.dark-mode .navbar-gray.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #636b72;
+  border-color: #575e64;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-gray.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #60686f;
+  border-color: #575e64 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar,
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #757f88;
+  border-color: #838c94;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-gray.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #78828a;
+  border-color: #838c94 !important;
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar::-moz-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar::-ms-input-placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar::placeholder {
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar,
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #2b3035;
+  border-color: #1f2327;
+  color: rgba(52, 58, 64, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus::-moz-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus:-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus::-ms-input-placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus::placeholder {
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus,
+.dark-mode .navbar-gray-dark.navbar-light .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #292d32;
+  border-color: #1f2327 !important;
+  color: #343a40;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar::-moz-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar::-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar::placeholder {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar,
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #3d444b;
+  border-color: #495159;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus::-webkit-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus::-moz-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus:-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus::-ms-input-placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus::placeholder {
+  color: #fff;
+}
+
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus,
+.dark-mode .navbar-gray-dark.navbar-dark .form-control-navbar:focus + .input-group-append .btn-navbar {
+  background-color: #3f474e;
+  border-color: #495159 !important;
+  color: #fff;
+}
+
 .pagination-month .page-item {
   justify-self: stretch;
 }
 
 .pagination-month .page-item .page-link {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-shadow: none;
@@ -14216,14 +21843,24 @@ body.text-sm .control-sidebar {
   font-size: 1rem;
 }
 
+.dark-mode .page-item.disabled a,
 .dark-mode .page-item.disabled .page-link {
-  background-color: #3a4047;
-  border-color: #6c757d;
+  background-color: #3a4047 !important;
+  border-color: #6c757d !important;
   color: #6c757d;
 }
 
+.dark-mode .page-item .page-link {
+  color: #3f6791;
+}
+
+.dark-mode .page-item.active .page-link {
+  background-color: #3f6791;
+  color: #fff;
+}
+
 .dark-mode .page-item.active .page-link:hover, .dark-mode .page-item.active .page-link:focus {
-  color: #ced4da;
+  color: #ced4da !important;
 }
 
 .dark-mode .page-item:not(.active) .page-link {
@@ -14232,7 +21869,7 @@ body.text-sm .control-sidebar {
 }
 
 .dark-mode .page-item:not(.active) .page-link:hover, .dark-mode .page-item:not(.active) .page-link:focus {
-  color: #1a88ff;
+  color: #4774a3;
   background-color: #3f474e;
 }
 
@@ -16925,7 +24562,30 @@ body.text-sm .input-group-text {
   background-color: transparent;
 }
 
-.dark-mode .form-control,
+.navbar-dark .btn-navbar,
+.navbar-dark .form-control-navbar {
+  background-color: #3f474e;
+  border: 1px solid #56606a;
+  color: white;
+}
+
+.navbar-dark .btn-navbar:hover {
+  background-color: #454d55;
+}
+
+.navbar-dark .btn-navbar:focus {
+  background-color: #4b545c;
+}
+
+.navbar-dark .form-control-navbar + .input-group-prepend > .btn-navbar,
+.navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
+  background-color: #3f474e;
+  color: #fff;
+  border: 1px solid #56606a;
+  border-left: none;
+}
+
+.dark-mode .form-control:not(.form-control-navbar):not(.form-control-sidebar),
 .dark-mode .custom-select,
 .dark-mode .custom-file-label,
 .dark-mode .custom-file-label::after,
@@ -16935,7 +24595,9 @@ body.text-sm .input-group-text {
   color: #fff;
 }
 
-.dark-mode .form-control:not(.form-control-navbar):not(.is-invalid):not(:focus) {
+.dark-mode .form-control:not(.form-control-navbar):not(.form-control-sidebar):not(.is-invalid):not(:focus),
+.dark-mode .custom-file-label,
+.dark-mode .custom-file-label::after {
   border-color: #6c757d;
 }
 
@@ -16968,26 +24630,2488 @@ body.text-sm .input-group-text {
   background-color: #454d55;
 }
 
-.dark-mode .navbar-dark .btn-navbar,
-.dark-mode .navbar-dark .form-control-navbar {
+.dark-mode .custom-range.custom-range-primary:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-primary:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-primary:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-primary:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-primary::-webkit-slider-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-primary::-webkit-slider-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-primary::-moz-range-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-primary::-moz-range-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-primary::-ms-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-primary::-ms-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-secondary:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-secondary:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-secondary:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-secondary:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-secondary::-webkit-slider-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-secondary::-webkit-slider-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-secondary::-moz-range-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-secondary::-moz-range-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-secondary::-ms-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-secondary::-ms-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-success:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-success:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-success:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-success:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-success::-webkit-slider-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-success::-webkit-slider-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-success::-moz-range-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-success::-moz-range-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-success::-ms-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-success::-ms-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-info:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-info:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-info:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-info:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-info::-webkit-slider-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-info::-webkit-slider-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-info::-moz-range-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-info::-moz-range-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-info::-ms-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-info::-ms-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-warning:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-warning:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-warning:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-warning:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-warning::-webkit-slider-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-warning::-webkit-slider-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-warning::-moz-range-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-warning::-moz-range-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-warning::-ms-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-warning::-ms-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-danger:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-danger:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-danger:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-danger:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-danger::-webkit-slider-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-danger::-webkit-slider-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-danger::-moz-range-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-danger::-moz-range-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-danger::-ms-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-danger::-ms-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-light:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-light:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-light:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-light:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-light::-webkit-slider-thumb {
+  background-color: #f8f9fa;
+}
+
+.dark-mode .custom-range.custom-range-light::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-light::-moz-range-thumb {
+  background-color: #f8f9fa;
+}
+
+.dark-mode .custom-range.custom-range-light::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-light::-ms-thumb {
+  background-color: #f8f9fa;
+}
+
+.dark-mode .custom-range.custom-range-light::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-dark:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-dark:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-dark:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-dark:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-dark::-webkit-slider-thumb {
   background-color: #343a40;
-  border: 1px solid #6c757d;
 }
 
-.dark-mode .navbar-dark .btn-navbar:hover {
-  background-color: #454d55;
+.dark-mode .custom-range.custom-range-dark::-webkit-slider-thumb:active {
+  background-color: #88939e;
 }
 
-.dark-mode .navbar-dark .btn-navbar:focus {
-  background-color: #4b545c;
+.dark-mode .custom-range.custom-range-dark::-moz-range-thumb {
+  background-color: #343a40;
 }
 
-.dark-mode .navbar-dark .form-control-navbar + .input-group-prepend > .btn-navbar,
-.dark-mode .navbar-dark .form-control-navbar + .input-group-append > .btn-navbar {
-  background-color: #3f474e;
-  color: #fff;
-  border: 1px solid #6c757d;
-  border-left: none;
+.dark-mode .custom-range.custom-range-dark::-moz-range-thumb:active {
+  background-color: #88939e;
+}
+
+.dark-mode .custom-range.custom-range-dark::-ms-thumb {
+  background-color: #343a40;
+}
+
+.dark-mode .custom-range.custom-range-dark::-ms-thumb:active {
+  background-color: #88939e;
+}
+
+.dark-mode .custom-range.custom-range-lightblue:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-lightblue:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lightblue:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lightblue:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-webkit-slider-thumb {
+  background-color: #86bad8;
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-moz-range-thumb {
+  background-color: #86bad8;
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-ms-thumb {
+  background-color: #86bad8;
+}
+
+.dark-mode .custom-range.custom-range-lightblue::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-navy:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-navy:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-navy:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-navy:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-navy::-webkit-slider-thumb {
+  background-color: #002c59;
+}
+
+.dark-mode .custom-range.custom-range-navy::-webkit-slider-thumb:active {
+  background-color: #0c84ff;
+}
+
+.dark-mode .custom-range.custom-range-navy::-moz-range-thumb {
+  background-color: #002c59;
+}
+
+.dark-mode .custom-range.custom-range-navy::-moz-range-thumb:active {
+  background-color: #0c84ff;
+}
+
+.dark-mode .custom-range.custom-range-navy::-ms-thumb {
+  background-color: #002c59;
+}
+
+.dark-mode .custom-range.custom-range-navy::-ms-thumb:active {
+  background-color: #0c84ff;
+}
+
+.dark-mode .custom-range.custom-range-olive:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-olive:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-olive:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-olive:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-olive::-webkit-slider-thumb {
+  background-color: #74c8a3;
+}
+
+.dark-mode .custom-range.custom-range-olive::-webkit-slider-thumb:active {
+  background-color: #f4fbf8;
+}
+
+.dark-mode .custom-range.custom-range-olive::-moz-range-thumb {
+  background-color: #74c8a3;
+}
+
+.dark-mode .custom-range.custom-range-olive::-moz-range-thumb:active {
+  background-color: #f4fbf8;
+}
+
+.dark-mode .custom-range.custom-range-olive::-ms-thumb {
+  background-color: #74c8a3;
+}
+
+.dark-mode .custom-range.custom-range-olive::-ms-thumb:active {
+  background-color: #f4fbf8;
+}
+
+.dark-mode .custom-range.custom-range-lime:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-lime:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lime:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lime:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-lime::-webkit-slider-thumb {
+  background-color: #67ffa9;
+}
+
+.dark-mode .custom-range.custom-range-lime::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-lime::-moz-range-thumb {
+  background-color: #67ffa9;
+}
+
+.dark-mode .custom-range.custom-range-lime::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-lime::-ms-thumb {
+  background-color: #67ffa9;
+}
+
+.dark-mode .custom-range.custom-range-lime::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-fuchsia:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-fuchsia:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-webkit-slider-thumb {
+  background-color: #f672d8;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-moz-range-thumb {
+  background-color: #f672d8;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-ms-thumb {
+  background-color: #f672d8;
+}
+
+.dark-mode .custom-range.custom-range-fuchsia::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-maroon:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-maroon:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-maroon:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-maroon:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-maroon::-webkit-slider-thumb {
+  background-color: #ed6c9b;
+}
+
+.dark-mode .custom-range.custom-range-maroon::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-maroon::-moz-range-thumb {
+  background-color: #ed6c9b;
+}
+
+.dark-mode .custom-range.custom-range-maroon::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-maroon::-ms-thumb {
+  background-color: #ed6c9b;
+}
+
+.dark-mode .custom-range.custom-range-maroon::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-blue:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-blue:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-blue:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-blue:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-blue::-webkit-slider-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-blue::-webkit-slider-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-blue::-moz-range-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-blue::-moz-range-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-blue::-ms-thumb {
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-range.custom-range-blue::-ms-thumb:active {
+  background-color: #a9c1da;
+}
+
+.dark-mode .custom-range.custom-range-indigo:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-indigo:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-indigo:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-indigo:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-indigo::-webkit-slider-thumb {
+  background-color: #6610f2;
+}
+
+.dark-mode .custom-range.custom-range-indigo::-webkit-slider-thumb:active {
+  background-color: #d2b9fb;
+}
+
+.dark-mode .custom-range.custom-range-indigo::-moz-range-thumb {
+  background-color: #6610f2;
+}
+
+.dark-mode .custom-range.custom-range-indigo::-moz-range-thumb:active {
+  background-color: #d2b9fb;
+}
+
+.dark-mode .custom-range.custom-range-indigo::-ms-thumb {
+  background-color: #6610f2;
+}
+
+.dark-mode .custom-range.custom-range-indigo::-ms-thumb:active {
+  background-color: #d2b9fb;
+}
+
+.dark-mode .custom-range.custom-range-purple:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-purple:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-purple:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-purple:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-purple::-webkit-slider-thumb {
+  background-color: #6f42c1;
+}
+
+.dark-mode .custom-range.custom-range-purple::-webkit-slider-thumb:active {
+  background-color: #d5c8ed;
+}
+
+.dark-mode .custom-range.custom-range-purple::-moz-range-thumb {
+  background-color: #6f42c1;
+}
+
+.dark-mode .custom-range.custom-range-purple::-moz-range-thumb:active {
+  background-color: #d5c8ed;
+}
+
+.dark-mode .custom-range.custom-range-purple::-ms-thumb {
+  background-color: #6f42c1;
+}
+
+.dark-mode .custom-range.custom-range-purple::-ms-thumb:active {
+  background-color: #d5c8ed;
+}
+
+.dark-mode .custom-range.custom-range-pink:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-pink:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-pink:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-pink:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-pink::-webkit-slider-thumb {
+  background-color: #e83e8c;
+}
+
+.dark-mode .custom-range.custom-range-pink::-webkit-slider-thumb:active {
+  background-color: #fbddeb;
+}
+
+.dark-mode .custom-range.custom-range-pink::-moz-range-thumb {
+  background-color: #e83e8c;
+}
+
+.dark-mode .custom-range.custom-range-pink::-moz-range-thumb:active {
+  background-color: #fbddeb;
+}
+
+.dark-mode .custom-range.custom-range-pink::-ms-thumb {
+  background-color: #e83e8c;
+}
+
+.dark-mode .custom-range.custom-range-pink::-ms-thumb:active {
+  background-color: #fbddeb;
+}
+
+.dark-mode .custom-range.custom-range-red:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-red:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-red:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-red:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-red::-webkit-slider-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-red::-webkit-slider-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-red::-moz-range-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-red::-moz-range-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-red::-ms-thumb {
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-range.custom-range-red::-ms-thumb:active {
+  background-color: #fbdedb;
+}
+
+.dark-mode .custom-range.custom-range-orange:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-orange:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-orange:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-orange:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-orange::-webkit-slider-thumb {
+  background-color: #fd7e14;
+}
+
+.dark-mode .custom-range.custom-range-orange::-webkit-slider-thumb:active {
+  background-color: #ffdfc5;
+}
+
+.dark-mode .custom-range.custom-range-orange::-moz-range-thumb {
+  background-color: #fd7e14;
+}
+
+.dark-mode .custom-range.custom-range-orange::-moz-range-thumb:active {
+  background-color: #ffdfc5;
+}
+
+.dark-mode .custom-range.custom-range-orange::-ms-thumb {
+  background-color: #fd7e14;
+}
+
+.dark-mode .custom-range.custom-range-orange::-ms-thumb:active {
+  background-color: #ffdfc5;
+}
+
+.dark-mode .custom-range.custom-range-yellow:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-yellow:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-yellow:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-yellow:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-yellow::-webkit-slider-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-yellow::-webkit-slider-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-yellow::-moz-range-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-yellow::-moz-range-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-yellow::-ms-thumb {
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-range.custom-range-yellow::-ms-thumb:active {
+  background-color: #fce3bc;
+}
+
+.dark-mode .custom-range.custom-range-green:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-green:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-green:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-green:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-green::-webkit-slider-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-green::-webkit-slider-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-green::-moz-range-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-green::-moz-range-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-green::-ms-thumb {
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-range.custom-range-green::-ms-thumb:active {
+  background-color: #70ffda;
+}
+
+.dark-mode .custom-range.custom-range-teal:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-teal:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-teal:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-teal:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-teal::-webkit-slider-thumb {
+  background-color: #20c997;
+}
+
+.dark-mode .custom-range.custom-range-teal::-webkit-slider-thumb:active {
+  background-color: #aaf1dc;
+}
+
+.dark-mode .custom-range.custom-range-teal::-moz-range-thumb {
+  background-color: #20c997;
+}
+
+.dark-mode .custom-range.custom-range-teal::-moz-range-thumb:active {
+  background-color: #aaf1dc;
+}
+
+.dark-mode .custom-range.custom-range-teal::-ms-thumb {
+  background-color: #20c997;
+}
+
+.dark-mode .custom-range.custom-range-teal::-ms-thumb:active {
+  background-color: #aaf1dc;
+}
+
+.dark-mode .custom-range.custom-range-cyan:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-cyan:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-cyan:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-cyan:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-cyan::-webkit-slider-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-cyan::-webkit-slider-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-cyan::-moz-range-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-cyan::-moz-range-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-cyan::-ms-thumb {
+  background-color: #3498db;
+}
+
+.dark-mode .custom-range.custom-range-cyan::-ms-thumb:active {
+  background-color: #cce5f6;
+}
+
+.dark-mode .custom-range.custom-range-white:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-white:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-white:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-white:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-white::-webkit-slider-thumb {
+  background-color: #fff;
+}
+
+.dark-mode .custom-range.custom-range-white::-webkit-slider-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-white::-moz-range-thumb {
+  background-color: #fff;
+}
+
+.dark-mode .custom-range.custom-range-white::-moz-range-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-white::-ms-thumb {
+  background-color: #fff;
+}
+
+.dark-mode .custom-range.custom-range-white::-ms-thumb:active {
+  background-color: white;
+}
+
+.dark-mode .custom-range.custom-range-gray:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-gray:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray::-webkit-slider-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-gray::-webkit-slider-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-gray::-moz-range-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-gray::-moz-range-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-gray::-ms-thumb {
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-range.custom-range-gray::-ms-thumb:active {
+  background-color: #caced1;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark:focus {
+  outline: none;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray-dark:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray-dark:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-webkit-slider-thumb {
+  background-color: #343a40;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-webkit-slider-thumb:active {
+  background-color: #88939e;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-moz-range-thumb {
+  background-color: #343a40;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-moz-range-thumb:active {
+  background-color: #88939e;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-ms-thumb {
+  background-color: #343a40;
+}
+
+.dark-mode .custom-range.custom-range-gray-dark::-ms-thumb:active {
+  background-color: #88939e;
+}
+
+.dark-mode .custom-switch.custom-switch-off-primary .custom-control-input ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .custom-switch.custom-switch-off-primary .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-primary .custom-control-input ~ .custom-control-label::after {
+  background-color: #182838;
+}
+
+.dark-mode .custom-switch.custom-switch-on-primary .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .custom-switch.custom-switch-on-primary .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-primary .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #97b4d2;
+}
+
+.dark-mode .custom-switch.custom-switch-off-secondary .custom-control-input ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .custom-switch.custom-switch-off-secondary .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-secondary .custom-control-input ~ .custom-control-label::after {
+  background-color: #313539;
+}
+
+.dark-mode .custom-switch.custom-switch-on-secondary .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .custom-switch.custom-switch-on-secondary .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-secondary .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #bcc1c6;
+}
+
+.dark-mode .custom-switch.custom-switch-off-success .custom-control-input ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .custom-switch.custom-switch-off-success .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-success .custom-control-input ~ .custom-control-label::after {
+  background-color: #003d2d;
+}
+
+.dark-mode .custom-switch.custom-switch-on-success .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .custom-switch.custom-switch-on-success .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-success .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #56ffd4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-info .custom-control-input ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .custom-switch.custom-switch-off-info .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-info .custom-control-input ~ .custom-control-label::after {
+  background-color: #16527a;
+}
+
+.dark-mode .custom-switch.custom-switch-on-info .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .custom-switch.custom-switch-on-info .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-info .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #b6daf2;
+}
+
+.dark-mode .custom-switch.custom-switch-off-warning .custom-control-input ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .custom-switch.custom-switch-off-warning .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-warning .custom-control-input ~ .custom-control-label::after {
+  background-color: #7f5006;
+}
+
+.dark-mode .custom-switch.custom-switch-on-warning .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .custom-switch.custom-switch-on-warning .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-warning .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fad9a4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-danger .custom-control-input ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .custom-switch.custom-switch-off-danger .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-danger .custom-control-input ~ .custom-control-label::after {
+  background-color: #921e12;
+}
+
+.dark-mode .custom-switch.custom-switch-on-danger .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .custom-switch.custom-switch-on-danger .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-danger .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #f8c9c4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-light .custom-control-input ~ .custom-control-label::before {
+  background-color: #f8f9fa;
+  border-color: #bdc6d0;
+}
+
+.dark-mode .custom-switch.custom-switch-off-light .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-light .custom-control-input ~ .custom-control-label::after {
+  background-color: #aeb9c5;
+}
+
+.dark-mode .custom-switch.custom-switch-on-light .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f8f9fa;
+  border-color: #bdc6d0;
+}
+
+.dark-mode .custom-switch.custom-switch-on-light .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-light .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: white;
+}
+
+.dark-mode .custom-switch.custom-switch-off-dark .custom-control-input ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .custom-switch.custom-switch-off-dark .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-dark .custom-control-input ~ .custom-control-label::after {
+  background-color: black;
+}
+
+.dark-mode .custom-switch.custom-switch-on-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .custom-switch.custom-switch-on-dark .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #7a8793;
+}
+
+.dark-mode .custom-switch.custom-switch-off-lightblue .custom-control-input ~ .custom-control-label::before {
+  background-color: #86bad8;
+  border-color: #3c8dbc;
+}
+
+.dark-mode .custom-switch.custom-switch-off-lightblue .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-lightblue .custom-control-input ~ .custom-control-label::after {
+  background-color: #367fa9;
+}
+
+.dark-mode .custom-switch.custom-switch-on-lightblue .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #86bad8;
+  border-color: #3c8dbc;
+}
+
+.dark-mode .custom-switch.custom-switch-on-lightblue .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-lightblue .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fafcfd;
+}
+
+.dark-mode .custom-switch.custom-switch-off-navy .custom-control-input ~ .custom-control-label::before {
+  background-color: #002c59;
+  border-color: black;
+}
+
+.dark-mode .custom-switch.custom-switch-off-navy .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-navy .custom-control-input ~ .custom-control-label::after {
+  background-color: black;
+}
+
+.dark-mode .custom-switch.custom-switch-on-navy .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #002c59;
+  border-color: black;
+}
+
+.dark-mode .custom-switch.custom-switch-on-navy .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-navy .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #0077f2;
+}
+
+.dark-mode .custom-switch.custom-switch-off-olive .custom-control-input ~ .custom-control-label::before {
+  background-color: #74c8a3;
+  border-color: #3d9970;
+}
+
+.dark-mode .custom-switch.custom-switch-off-olive .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-olive .custom-control-input ~ .custom-control-label::after {
+  background-color: #368763;
+}
+
+.dark-mode .custom-switch.custom-switch-on-olive .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #74c8a3;
+  border-color: #3d9970;
+}
+
+.dark-mode .custom-switch.custom-switch-on-olive .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-olive .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #e2f3eb;
+}
+
+.dark-mode .custom-switch.custom-switch-off-lime .custom-control-input ~ .custom-control-label::before {
+  background-color: #67ffa9;
+  border-color: #01ff70;
+}
+
+.dark-mode .custom-switch.custom-switch-off-lime .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-lime .custom-control-input ~ .custom-control-label::after {
+  background-color: #00e765;
+}
+
+.dark-mode .custom-switch.custom-switch-on-lime .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #67ffa9;
+  border-color: #01ff70;
+}
+
+.dark-mode .custom-switch.custom-switch-on-lime .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-lime .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: white;
+}
+
+.dark-mode .custom-switch.custom-switch-off-fuchsia .custom-control-input ~ .custom-control-label::before {
+  background-color: #f672d8;
+  border-color: #f012be;
+}
+
+.dark-mode .custom-switch.custom-switch-off-fuchsia .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-fuchsia .custom-control-input ~ .custom-control-label::after {
+  background-color: #db0ead;
+}
+
+.dark-mode .custom-switch.custom-switch-on-fuchsia .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f672d8;
+  border-color: #f012be;
+}
+
+.dark-mode .custom-switch.custom-switch-on-fuchsia .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-fuchsia .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: white;
+}
+
+.dark-mode .custom-switch.custom-switch-off-maroon .custom-control-input ~ .custom-control-label::before {
+  background-color: #ed6c9b;
+  border-color: #d81b60;
+}
+
+.dark-mode .custom-switch.custom-switch-off-maroon .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-maroon .custom-control-input ~ .custom-control-label::after {
+  background-color: #c11856;
+}
+
+.dark-mode .custom-switch.custom-switch-on-maroon .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #ed6c9b;
+  border-color: #d81b60;
+}
+
+.dark-mode .custom-switch.custom-switch-on-maroon .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-maroon .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fef4f8;
+}
+
+.dark-mode .custom-switch.custom-switch-off-blue .custom-control-input ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .custom-switch.custom-switch-off-blue .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-blue .custom-control-input ~ .custom-control-label::after {
+  background-color: #182838;
+}
+
+.dark-mode .custom-switch.custom-switch-on-blue .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .custom-switch.custom-switch-on-blue .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-blue .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #97b4d2;
+}
+
+.dark-mode .custom-switch.custom-switch-off-indigo .custom-control-input ~ .custom-control-label::before {
+  background-color: #6610f2;
+  border-color: #3d0894;
+}
+
+.dark-mode .custom-switch.custom-switch-off-indigo .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-indigo .custom-control-input ~ .custom-control-label::after {
+  background-color: #33077c;
+}
+
+.dark-mode .custom-switch.custom-switch-on-indigo .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6610f2;
+  border-color: #3d0894;
+}
+
+.dark-mode .custom-switch.custom-switch-on-indigo .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-indigo .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #c3a1fa;
+}
+
+.dark-mode .custom-switch.custom-switch-off-purple .custom-control-input ~ .custom-control-label::before {
+  background-color: #6f42c1;
+  border-color: #432776;
+}
+
+.dark-mode .custom-switch.custom-switch-off-purple .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-purple .custom-control-input ~ .custom-control-label::after {
+  background-color: #382063;
+}
+
+.dark-mode .custom-switch.custom-switch-on-purple .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6f42c1;
+  border-color: #432776;
+}
+
+.dark-mode .custom-switch.custom-switch-on-purple .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-purple .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #c7b5e7;
+}
+
+.dark-mode .custom-switch.custom-switch-off-pink .custom-control-input ~ .custom-control-label::before {
+  background-color: #e83e8c;
+  border-color: #ac145a;
+}
+
+.dark-mode .custom-switch.custom-switch-off-pink .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-pink .custom-control-input ~ .custom-control-label::after {
+  background-color: #95124e;
+}
+
+.dark-mode .custom-switch.custom-switch-on-pink .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e83e8c;
+  border-color: #ac145a;
+}
+
+.dark-mode .custom-switch.custom-switch-on-pink .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-pink .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #f8c7dd;
+}
+
+.dark-mode .custom-switch.custom-switch-off-red .custom-control-input ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .custom-switch.custom-switch-off-red .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-red .custom-control-input ~ .custom-control-label::after {
+  background-color: #921e12;
+}
+
+.dark-mode .custom-switch.custom-switch-on-red .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .custom-switch.custom-switch-on-red .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-red .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #f8c9c4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-orange .custom-control-input ~ .custom-control-label::before {
+  background-color: #fd7e14;
+  border-color: #aa4e01;
+}
+
+.dark-mode .custom-switch.custom-switch-off-orange .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-orange .custom-control-input ~ .custom-control-label::after {
+  background-color: #904201;
+}
+
+.dark-mode .custom-switch.custom-switch-on-orange .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #fd7e14;
+  border-color: #aa4e01;
+}
+
+.dark-mode .custom-switch.custom-switch-on-orange .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-orange .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fed1ac;
+}
+
+.dark-mode .custom-switch.custom-switch-off-yellow .custom-control-input ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .custom-switch.custom-switch-off-yellow .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-yellow .custom-control-input ~ .custom-control-label::after {
+  background-color: #7f5006;
+}
+
+.dark-mode .custom-switch.custom-switch-on-yellow .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .custom-switch.custom-switch-on-yellow .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-yellow .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fad9a4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-green .custom-control-input ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .custom-switch.custom-switch-off-green .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-green .custom-control-input ~ .custom-control-label::after {
+  background-color: #003d2d;
+}
+
+.dark-mode .custom-switch.custom-switch-on-green .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .custom-switch.custom-switch-on-green .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-green .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #56ffd4;
+}
+
+.dark-mode .custom-switch.custom-switch-off-teal .custom-control-input ~ .custom-control-label::before {
+  background-color: #20c997;
+  border-color: #127155;
+}
+
+.dark-mode .custom-switch.custom-switch-off-teal .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-teal .custom-control-input ~ .custom-control-label::after {
+  background-color: #0e5b44;
+}
+
+.dark-mode .custom-switch.custom-switch-on-teal .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #20c997;
+  border-color: #127155;
+}
+
+.dark-mode .custom-switch.custom-switch-on-teal .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-teal .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #94eed3;
+}
+
+.dark-mode .custom-switch.custom-switch-off-cyan .custom-control-input ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .custom-switch.custom-switch-off-cyan .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-cyan .custom-control-input ~ .custom-control-label::after {
+  background-color: #16527a;
+}
+
+.dark-mode .custom-switch.custom-switch-on-cyan .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .custom-switch.custom-switch-on-cyan .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-cyan .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #b6daf2;
+}
+
+.dark-mode .custom-switch.custom-switch-off-white .custom-control-input ~ .custom-control-label::before {
+  background-color: #fff;
+  border-color: #cccccc;
+}
+
+.dark-mode .custom-switch.custom-switch-off-white .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-white .custom-control-input ~ .custom-control-label::after {
+  background-color: #bfbfbf;
+}
+
+.dark-mode .custom-switch.custom-switch-on-white .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #fff;
+  border-color: #cccccc;
+}
+
+.dark-mode .custom-switch.custom-switch-on-white .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-white .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: white;
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray .custom-control-input ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray .custom-control-input ~ .custom-control-label::after {
+  background-color: #313539;
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #bcc1c6;
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray-dark .custom-control-input ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray-dark .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-off-gray-dark .custom-control-input ~ .custom-control-label::after {
+  background-color: black;
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray-dark .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-switch.custom-switch-on-gray-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #7a8793;
+}
+
+.dark-mode .custom-control-input-primary:checked ~ .custom-control-label::before {
+  border-color: #3f6791;
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-control-input-primary.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%233f6791' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-primary.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%233f6791'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-primary:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-control-input-primary:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #85a7ca;
+}
+
+.dark-mode .custom-control-input-primary:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #a9c1da;
+  border-color: #a9c1da;
+}
+
+.dark-mode .custom-control-input-secondary:checked ~ .custom-control-label::before {
+  border-color: #6c757d;
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-control-input-secondary.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%236c757d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-secondary.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%236c757d'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-secondary:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-control-input-secondary:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #afb5ba;
+}
+
+.dark-mode .custom-control-input-secondary:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #caced1;
+  border-color: #caced1;
+}
+
+.dark-mode .custom-control-input-success:checked ~ .custom-control-label::before {
+  border-color: #00bc8c;
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-control-input-success.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2300bc8c' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-success.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2300bc8c'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-success:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-control-input-success:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #3dffcd;
+}
+
+.dark-mode .custom-control-input-success:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #70ffda;
+  border-color: #70ffda;
+}
+
+.dark-mode .custom-control-input-info:checked ~ .custom-control-label::before {
+  border-color: #3498db;
+  background-color: #3498db;
+}
+
+.dark-mode .custom-control-input-info.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%233498db' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-info.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%233498db'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-info:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-control-input-info:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #a0cfee;
+}
+
+.dark-mode .custom-control-input-info:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #cce5f6;
+  border-color: #cce5f6;
+}
+
+.dark-mode .custom-control-input-warning:checked ~ .custom-control-label::before {
+  border-color: #f39c12;
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-control-input-warning.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23f39c12' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-warning.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23f39c12'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-warning:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-control-input-warning:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .custom-control-input-warning:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #fce3bc;
+  border-color: #fce3bc;
+}
+
+.dark-mode .custom-control-input-danger:checked ~ .custom-control-label::before {
+  border-color: #e74c3c;
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-control-input-danger.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23e74c3c' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-danger.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23e74c3c'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-danger:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-control-input-danger:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .custom-control-input-danger:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #fbdedb;
+  border-color: #fbdedb;
+}
+
+.dark-mode .custom-control-input-light:checked ~ .custom-control-label::before {
+  border-color: #f8f9fa;
+  background-color: #f8f9fa;
+}
+
+.dark-mode .custom-control-input-light.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23f8f9fa' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-light.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23f8f9fa'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-light:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(248, 249, 250, 0.25);
+}
+
+.dark-mode .custom-control-input-light:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-light:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-dark:checked ~ .custom-control-label::before {
+  border-color: #343a40;
+  background-color: #343a40;
+}
+
+.dark-mode .custom-control-input-dark.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23343a40' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-dark.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23343a40'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-dark:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-control-input-dark:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #6d7a86;
+}
+
+.dark-mode .custom-control-input-dark:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #88939e;
+  border-color: #88939e;
+}
+
+.dark-mode .custom-control-input-lightblue:checked ~ .custom-control-label::before {
+  border-color: #86bad8;
+  background-color: #86bad8;
+}
+
+.dark-mode .custom-control-input-lightblue.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2386bad8' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-lightblue.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2386bad8'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-lightblue:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(134, 186, 216, 0.25);
+}
+
+.dark-mode .custom-control-input-lightblue:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #e6f1f7;
+}
+
+.dark-mode .custom-control-input-lightblue:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-navy:checked ~ .custom-control-label::before {
+  border-color: #002c59;
+  background-color: #002c59;
+}
+
+.dark-mode .custom-control-input-navy.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23002c59' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-navy.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23002c59'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-navy:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(0, 44, 89, 0.25);
+}
+
+.dark-mode .custom-control-input-navy:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #006ad8;
+}
+
+.dark-mode .custom-control-input-navy:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #0c84ff;
+  border-color: #0c84ff;
+}
+
+.dark-mode .custom-control-input-olive:checked ~ .custom-control-label::before {
+  border-color: #74c8a3;
+  background-color: #74c8a3;
+}
+
+.dark-mode .custom-control-input-olive.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2374c8a3' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-olive.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2374c8a3'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-olive:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(116, 200, 163, 0.25);
+}
+
+.dark-mode .custom-control-input-olive:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #cfecdf;
+}
+
+.dark-mode .custom-control-input-olive:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #f4fbf8;
+  border-color: #f4fbf8;
+}
+
+.dark-mode .custom-control-input-lime:checked ~ .custom-control-label::before {
+  border-color: #67ffa9;
+  background-color: #67ffa9;
+}
+
+.dark-mode .custom-control-input-lime.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2367ffa9' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-lime.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2367ffa9'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-lime:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(103, 255, 169, 0.25);
+}
+
+.dark-mode .custom-control-input-lime:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #e7fff1;
+}
+
+.dark-mode .custom-control-input-lime:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-fuchsia:checked ~ .custom-control-label::before {
+  border-color: #f672d8;
+  background-color: #f672d8;
+}
+
+.dark-mode .custom-control-input-fuchsia.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23f672d8' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-fuchsia.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23f672d8'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-fuchsia:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(246, 114, 216, 0.25);
+}
+
+.dark-mode .custom-control-input-fuchsia:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #feeaf9;
+}
+
+.dark-mode .custom-control-input-fuchsia:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-maroon:checked ~ .custom-control-label::before {
+  border-color: #ed6c9b;
+  background-color: #ed6c9b;
+}
+
+.dark-mode .custom-control-input-maroon.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ed6c9b' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-maroon.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23ed6c9b'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-maroon:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(237, 108, 155, 0.25);
+}
+
+.dark-mode .custom-control-input-maroon:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #fbdee8;
+}
+
+.dark-mode .custom-control-input-maroon:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-blue:checked ~ .custom-control-label::before {
+  border-color: #3f6791;
+  background-color: #3f6791;
+}
+
+.dark-mode .custom-control-input-blue.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%233f6791' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-blue.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%233f6791'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-blue:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(63, 103, 145, 0.25);
+}
+
+.dark-mode .custom-control-input-blue:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #85a7ca;
+}
+
+.dark-mode .custom-control-input-blue:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #a9c1da;
+  border-color: #a9c1da;
+}
+
+.dark-mode .custom-control-input-indigo:checked ~ .custom-control-label::before {
+  border-color: #6610f2;
+  background-color: #6610f2;
+}
+
+.dark-mode .custom-control-input-indigo.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%236610f2' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-indigo.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%236610f2'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-indigo:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(102, 16, 242, 0.25);
+}
+
+.dark-mode .custom-control-input-indigo:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #b389f9;
+}
+
+.dark-mode .custom-control-input-indigo:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #d2b9fb;
+  border-color: #d2b9fb;
+}
+
+.dark-mode .custom-control-input-purple:checked ~ .custom-control-label::before {
+  border-color: #6f42c1;
+  background-color: #6f42c1;
+}
+
+.dark-mode .custom-control-input-purple.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%236f42c1' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-purple.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%236f42c1'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-purple:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(111, 66, 193, 0.25);
+}
+
+.dark-mode .custom-control-input-purple:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #b8a2e0;
+}
+
+.dark-mode .custom-control-input-purple:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #d5c8ed;
+  border-color: #d5c8ed;
+}
+
+.dark-mode .custom-control-input-pink:checked ~ .custom-control-label::before {
+  border-color: #e83e8c;
+  background-color: #e83e8c;
+}
+
+.dark-mode .custom-control-input-pink.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23e83e8c' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-pink.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23e83e8c'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-pink:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(232, 62, 140, 0.25);
+}
+
+.dark-mode .custom-control-input-pink:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #f6b0d0;
+}
+
+.dark-mode .custom-control-input-pink:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #fbddeb;
+  border-color: #fbddeb;
+}
+
+.dark-mode .custom-control-input-red:checked ~ .custom-control-label::before {
+  border-color: #e74c3c;
+  background-color: #e74c3c;
+}
+
+.dark-mode .custom-control-input-red.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23e74c3c' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-red.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23e74c3c'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-red:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(231, 76, 60, 0.25);
+}
+
+.dark-mode .custom-control-input-red:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .custom-control-input-red:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #fbdedb;
+  border-color: #fbdedb;
+}
+
+.dark-mode .custom-control-input-orange:checked ~ .custom-control-label::before {
+  border-color: #fd7e14;
+  background-color: #fd7e14;
+}
+
+.dark-mode .custom-control-input-orange.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fd7e14' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-orange.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23fd7e14'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-orange:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(253, 126, 20, 0.25);
+}
+
+.dark-mode .custom-control-input-orange:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #fec392;
+}
+
+.dark-mode .custom-control-input-orange:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #ffdfc5;
+  border-color: #ffdfc5;
+}
+
+.dark-mode .custom-control-input-yellow:checked ~ .custom-control-label::before {
+  border-color: #f39c12;
+  background-color: #f39c12;
+}
+
+.dark-mode .custom-control-input-yellow.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23f39c12' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-yellow.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23f39c12'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-yellow:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(243, 156, 18, 0.25);
+}
+
+.dark-mode .custom-control-input-yellow:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .custom-control-input-yellow:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #fce3bc;
+  border-color: #fce3bc;
+}
+
+.dark-mode .custom-control-input-green:checked ~ .custom-control-label::before {
+  border-color: #00bc8c;
+  background-color: #00bc8c;
+}
+
+.dark-mode .custom-control-input-green.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2300bc8c' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-green.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2300bc8c'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-green:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(0, 188, 140, 0.25);
+}
+
+.dark-mode .custom-control-input-green:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #3dffcd;
+}
+
+.dark-mode .custom-control-input-green:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #70ffda;
+  border-color: #70ffda;
+}
+
+.dark-mode .custom-control-input-teal:checked ~ .custom-control-label::before {
+  border-color: #20c997;
+  background-color: #20c997;
+}
+
+.dark-mode .custom-control-input-teal.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2320c997' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-teal.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%2320c997'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-teal:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(32, 201, 151, 0.25);
+}
+
+.dark-mode .custom-control-input-teal:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #7eeaca;
+}
+
+.dark-mode .custom-control-input-teal:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #aaf1dc;
+  border-color: #aaf1dc;
+}
+
+.dark-mode .custom-control-input-cyan:checked ~ .custom-control-label::before {
+  border-color: #3498db;
+  background-color: #3498db;
+}
+
+.dark-mode .custom-control-input-cyan.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%233498db' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-cyan.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%233498db'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-cyan:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(52, 152, 219, 0.25);
+}
+
+.dark-mode .custom-control-input-cyan:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #a0cfee;
+}
+
+.dark-mode .custom-control-input-cyan:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #cce5f6;
+  border-color: #cce5f6;
+}
+
+.dark-mode .custom-control-input-white:checked ~ .custom-control-label::before {
+  border-color: #fff;
+  background-color: #fff;
+}
+
+.dark-mode .custom-control-input-white.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-white.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23fff'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-white:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(255, 255, 255, 0.25);
+}
+
+.dark-mode .custom-control-input-white:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-white:not(:disabled):active ~ .custom-control-label::before {
+  background-color: white;
+  border-color: white;
+}
+
+.dark-mode .custom-control-input-gray:checked ~ .custom-control-label::before {
+  border-color: #6c757d;
+  background-color: #6c757d;
+}
+
+.dark-mode .custom-control-input-gray.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%236c757d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-gray.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%236c757d'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-gray:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(108, 117, 125, 0.25);
+}
+
+.dark-mode .custom-control-input-gray:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #afb5ba;
+}
+
+.dark-mode .custom-control-input-gray:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #caced1;
+  border-color: #caced1;
+}
+
+.dark-mode .custom-control-input-gray-dark:checked ~ .custom-control-label::before {
+  border-color: #343a40;
+  background-color: #343a40;
+}
+
+.dark-mode .custom-control-input-gray-dark.custom-control-input-outline:checked[type="checkbox"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23343a40' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-gray-dark.custom-control-input-outline:checked[type="radio"] ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23343a40'/%3E%3C/svg%3E") !important;
+}
+
+.dark-mode .custom-control-input-gray-dark:focus ~ .custom-control-label::before {
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 0 0 0.2rem rgba(52, 58, 64, 0.25);
+}
+
+.dark-mode .custom-control-input-gray-dark:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #6d7a86;
+}
+
+.dark-mode .custom-control-input-gray-dark:not(:disabled):active ~ .custom-control-label::before {
+  background-color: #88939e;
+  border-color: #88939e;
 }
 
 .progress {
@@ -17070,15 +27194,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #007bff;
 }
 
-.bg-primary .btn-tool,
-.bg-gradient-primary .btn-tool,
-.card-primary:not(.card-outline) .btn-tool {
+.bg-primary > .card-header .btn-tool,
+.bg-gradient-primary > .card-header .btn-tool,
+.card-primary:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-primary .btn-tool:hover,
-.bg-gradient-primary .btn-tool:hover,
-.card-primary:not(.card-outline) .btn-tool:hover {
+.bg-primary > .card-header .btn-tool:hover,
+.bg-gradient-primary > .card-header .btn-tool:hover,
+.card-primary:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17141,15 +27265,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #6c757d;
 }
 
-.bg-secondary .btn-tool,
-.bg-gradient-secondary .btn-tool,
-.card-secondary:not(.card-outline) .btn-tool {
+.bg-secondary > .card-header .btn-tool,
+.bg-gradient-secondary > .card-header .btn-tool,
+.card-secondary:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-secondary .btn-tool:hover,
-.bg-gradient-secondary .btn-tool:hover,
-.card-secondary:not(.card-outline) .btn-tool:hover {
+.bg-secondary > .card-header .btn-tool:hover,
+.bg-gradient-secondary > .card-header .btn-tool:hover,
+.card-secondary:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17212,15 +27336,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #28a745;
 }
 
-.bg-success .btn-tool,
-.bg-gradient-success .btn-tool,
-.card-success:not(.card-outline) .btn-tool {
+.bg-success > .card-header .btn-tool,
+.bg-gradient-success > .card-header .btn-tool,
+.card-success:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-success .btn-tool:hover,
-.bg-gradient-success .btn-tool:hover,
-.card-success:not(.card-outline) .btn-tool:hover {
+.bg-success > .card-header .btn-tool:hover,
+.bg-gradient-success > .card-header .btn-tool:hover,
+.card-success:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17283,15 +27407,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #17a2b8;
 }
 
-.bg-info .btn-tool,
-.bg-gradient-info .btn-tool,
-.card-info:not(.card-outline) .btn-tool {
+.bg-info > .card-header .btn-tool,
+.bg-gradient-info > .card-header .btn-tool,
+.card-info:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-info .btn-tool:hover,
-.bg-gradient-info .btn-tool:hover,
-.card-info:not(.card-outline) .btn-tool:hover {
+.bg-info > .card-header .btn-tool:hover,
+.bg-gradient-info > .card-header .btn-tool:hover,
+.card-info:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17354,15 +27478,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #ffc107;
 }
 
-.bg-warning .btn-tool,
-.bg-gradient-warning .btn-tool,
-.card-warning:not(.card-outline) .btn-tool {
+.bg-warning > .card-header .btn-tool,
+.bg-gradient-warning > .card-header .btn-tool,
+.card-warning:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-warning .btn-tool:hover,
-.bg-gradient-warning .btn-tool:hover,
-.card-warning:not(.card-outline) .btn-tool:hover {
+.bg-warning > .card-header .btn-tool:hover,
+.bg-gradient-warning > .card-header .btn-tool:hover,
+.card-warning:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -17425,15 +27549,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #dc3545;
 }
 
-.bg-danger .btn-tool,
-.bg-gradient-danger .btn-tool,
-.card-danger:not(.card-outline) .btn-tool {
+.bg-danger > .card-header .btn-tool,
+.bg-gradient-danger > .card-header .btn-tool,
+.card-danger:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-danger .btn-tool:hover,
-.bg-gradient-danger .btn-tool:hover,
-.card-danger:not(.card-outline) .btn-tool:hover {
+.bg-danger > .card-header .btn-tool:hover,
+.bg-gradient-danger > .card-header .btn-tool:hover,
+.card-danger:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17496,15 +27620,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #f8f9fa;
 }
 
-.bg-light .btn-tool,
-.bg-gradient-light .btn-tool,
-.card-light:not(.card-outline) .btn-tool {
+.bg-light > .card-header .btn-tool,
+.bg-gradient-light > .card-header .btn-tool,
+.card-light:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-light .btn-tool:hover,
-.bg-gradient-light .btn-tool:hover,
-.card-light:not(.card-outline) .btn-tool:hover {
+.bg-light > .card-header .btn-tool:hover,
+.bg-gradient-light > .card-header .btn-tool:hover,
+.card-light:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -17567,15 +27691,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #343a40;
 }
 
-.bg-dark .btn-tool,
-.bg-gradient-dark .btn-tool,
-.card-dark:not(.card-outline) .btn-tool {
+.bg-dark > .card-header .btn-tool,
+.bg-gradient-dark > .card-header .btn-tool,
+.card-dark:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-dark .btn-tool:hover,
-.bg-gradient-dark .btn-tool:hover,
-.card-dark:not(.card-outline) .btn-tool:hover {
+.bg-dark > .card-header .btn-tool:hover,
+.bg-gradient-dark > .card-header .btn-tool:hover,
+.card-dark:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17638,15 +27762,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #3c8dbc;
 }
 
-.bg-lightblue .btn-tool,
-.bg-gradient-lightblue .btn-tool,
-.card-lightblue:not(.card-outline) .btn-tool {
+.bg-lightblue > .card-header .btn-tool,
+.bg-gradient-lightblue > .card-header .btn-tool,
+.card-lightblue:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-lightblue .btn-tool:hover,
-.bg-gradient-lightblue .btn-tool:hover,
-.card-lightblue:not(.card-outline) .btn-tool:hover {
+.bg-lightblue > .card-header .btn-tool:hover,
+.bg-gradient-lightblue > .card-header .btn-tool:hover,
+.card-lightblue:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17709,15 +27833,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #001f3f;
 }
 
-.bg-navy .btn-tool,
-.bg-gradient-navy .btn-tool,
-.card-navy:not(.card-outline) .btn-tool {
+.bg-navy > .card-header .btn-tool,
+.bg-gradient-navy > .card-header .btn-tool,
+.card-navy:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-navy .btn-tool:hover,
-.bg-gradient-navy .btn-tool:hover,
-.card-navy:not(.card-outline) .btn-tool:hover {
+.bg-navy > .card-header .btn-tool:hover,
+.bg-gradient-navy > .card-header .btn-tool:hover,
+.card-navy:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17780,15 +27904,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #3d9970;
 }
 
-.bg-olive .btn-tool,
-.bg-gradient-olive .btn-tool,
-.card-olive:not(.card-outline) .btn-tool {
+.bg-olive > .card-header .btn-tool,
+.bg-gradient-olive > .card-header .btn-tool,
+.card-olive:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-olive .btn-tool:hover,
-.bg-gradient-olive .btn-tool:hover,
-.card-olive:not(.card-outline) .btn-tool:hover {
+.bg-olive > .card-header .btn-tool:hover,
+.bg-gradient-olive > .card-header .btn-tool:hover,
+.card-olive:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17851,15 +27975,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #01ff70;
 }
 
-.bg-lime .btn-tool,
-.bg-gradient-lime .btn-tool,
-.card-lime:not(.card-outline) .btn-tool {
+.bg-lime > .card-header .btn-tool,
+.bg-gradient-lime > .card-header .btn-tool,
+.card-lime:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-lime .btn-tool:hover,
-.bg-gradient-lime .btn-tool:hover,
-.card-lime:not(.card-outline) .btn-tool:hover {
+.bg-lime > .card-header .btn-tool:hover,
+.bg-gradient-lime > .card-header .btn-tool:hover,
+.card-lime:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -17922,15 +28046,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #f012be;
 }
 
-.bg-fuchsia .btn-tool,
-.bg-gradient-fuchsia .btn-tool,
-.card-fuchsia:not(.card-outline) .btn-tool {
+.bg-fuchsia > .card-header .btn-tool,
+.bg-gradient-fuchsia > .card-header .btn-tool,
+.card-fuchsia:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-fuchsia .btn-tool:hover,
-.bg-gradient-fuchsia .btn-tool:hover,
-.card-fuchsia:not(.card-outline) .btn-tool:hover {
+.bg-fuchsia > .card-header .btn-tool:hover,
+.bg-gradient-fuchsia > .card-header .btn-tool:hover,
+.card-fuchsia:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -17993,15 +28117,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #d81b60;
 }
 
-.bg-maroon .btn-tool,
-.bg-gradient-maroon .btn-tool,
-.card-maroon:not(.card-outline) .btn-tool {
+.bg-maroon > .card-header .btn-tool,
+.bg-gradient-maroon > .card-header .btn-tool,
+.card-maroon:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-maroon .btn-tool:hover,
-.bg-gradient-maroon .btn-tool:hover,
-.card-maroon:not(.card-outline) .btn-tool:hover {
+.bg-maroon > .card-header .btn-tool:hover,
+.bg-gradient-maroon > .card-header .btn-tool:hover,
+.card-maroon:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18064,15 +28188,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #007bff;
 }
 
-.bg-blue .btn-tool,
-.bg-gradient-blue .btn-tool,
-.card-blue:not(.card-outline) .btn-tool {
+.bg-blue > .card-header .btn-tool,
+.bg-gradient-blue > .card-header .btn-tool,
+.card-blue:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-blue .btn-tool:hover,
-.bg-gradient-blue .btn-tool:hover,
-.card-blue:not(.card-outline) .btn-tool:hover {
+.bg-blue > .card-header .btn-tool:hover,
+.bg-gradient-blue > .card-header .btn-tool:hover,
+.card-blue:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18135,15 +28259,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #6610f2;
 }
 
-.bg-indigo .btn-tool,
-.bg-gradient-indigo .btn-tool,
-.card-indigo:not(.card-outline) .btn-tool {
+.bg-indigo > .card-header .btn-tool,
+.bg-gradient-indigo > .card-header .btn-tool,
+.card-indigo:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-indigo .btn-tool:hover,
-.bg-gradient-indigo .btn-tool:hover,
-.card-indigo:not(.card-outline) .btn-tool:hover {
+.bg-indigo > .card-header .btn-tool:hover,
+.bg-gradient-indigo > .card-header .btn-tool:hover,
+.card-indigo:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18206,15 +28330,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #6f42c1;
 }
 
-.bg-purple .btn-tool,
-.bg-gradient-purple .btn-tool,
-.card-purple:not(.card-outline) .btn-tool {
+.bg-purple > .card-header .btn-tool,
+.bg-gradient-purple > .card-header .btn-tool,
+.card-purple:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-purple .btn-tool:hover,
-.bg-gradient-purple .btn-tool:hover,
-.card-purple:not(.card-outline) .btn-tool:hover {
+.bg-purple > .card-header .btn-tool:hover,
+.bg-gradient-purple > .card-header .btn-tool:hover,
+.card-purple:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18277,15 +28401,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #e83e8c;
 }
 
-.bg-pink .btn-tool,
-.bg-gradient-pink .btn-tool,
-.card-pink:not(.card-outline) .btn-tool {
+.bg-pink > .card-header .btn-tool,
+.bg-gradient-pink > .card-header .btn-tool,
+.card-pink:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-pink .btn-tool:hover,
-.bg-gradient-pink .btn-tool:hover,
-.card-pink:not(.card-outline) .btn-tool:hover {
+.bg-pink > .card-header .btn-tool:hover,
+.bg-gradient-pink > .card-header .btn-tool:hover,
+.card-pink:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18348,15 +28472,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #dc3545;
 }
 
-.bg-red .btn-tool,
-.bg-gradient-red .btn-tool,
-.card-red:not(.card-outline) .btn-tool {
+.bg-red > .card-header .btn-tool,
+.bg-gradient-red > .card-header .btn-tool,
+.card-red:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-red .btn-tool:hover,
-.bg-gradient-red .btn-tool:hover,
-.card-red:not(.card-outline) .btn-tool:hover {
+.bg-red > .card-header .btn-tool:hover,
+.bg-gradient-red > .card-header .btn-tool:hover,
+.card-red:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18419,15 +28543,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #fd7e14;
 }
 
-.bg-orange .btn-tool,
-.bg-gradient-orange .btn-tool,
-.card-orange:not(.card-outline) .btn-tool {
+.bg-orange > .card-header .btn-tool,
+.bg-gradient-orange > .card-header .btn-tool,
+.card-orange:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-orange .btn-tool:hover,
-.bg-gradient-orange .btn-tool:hover,
-.card-orange:not(.card-outline) .btn-tool:hover {
+.bg-orange > .card-header .btn-tool:hover,
+.bg-gradient-orange > .card-header .btn-tool:hover,
+.card-orange:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -18490,15 +28614,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #ffc107;
 }
 
-.bg-yellow .btn-tool,
-.bg-gradient-yellow .btn-tool,
-.card-yellow:not(.card-outline) .btn-tool {
+.bg-yellow > .card-header .btn-tool,
+.bg-gradient-yellow > .card-header .btn-tool,
+.card-yellow:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-yellow .btn-tool:hover,
-.bg-gradient-yellow .btn-tool:hover,
-.card-yellow:not(.card-outline) .btn-tool:hover {
+.bg-yellow > .card-header .btn-tool:hover,
+.bg-gradient-yellow > .card-header .btn-tool:hover,
+.card-yellow:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -18561,15 +28685,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #28a745;
 }
 
-.bg-green .btn-tool,
-.bg-gradient-green .btn-tool,
-.card-green:not(.card-outline) .btn-tool {
+.bg-green > .card-header .btn-tool,
+.bg-gradient-green > .card-header .btn-tool,
+.card-green:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-green .btn-tool:hover,
-.bg-gradient-green .btn-tool:hover,
-.card-green:not(.card-outline) .btn-tool:hover {
+.bg-green > .card-header .btn-tool:hover,
+.bg-gradient-green > .card-header .btn-tool:hover,
+.card-green:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18632,15 +28756,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #20c997;
 }
 
-.bg-teal .btn-tool,
-.bg-gradient-teal .btn-tool,
-.card-teal:not(.card-outline) .btn-tool {
+.bg-teal > .card-header .btn-tool,
+.bg-gradient-teal > .card-header .btn-tool,
+.card-teal:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-teal .btn-tool:hover,
-.bg-gradient-teal .btn-tool:hover,
-.card-teal:not(.card-outline) .btn-tool:hover {
+.bg-teal > .card-header .btn-tool:hover,
+.bg-gradient-teal > .card-header .btn-tool:hover,
+.card-teal:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18703,15 +28827,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #17a2b8;
 }
 
-.bg-cyan .btn-tool,
-.bg-gradient-cyan .btn-tool,
-.card-cyan:not(.card-outline) .btn-tool {
+.bg-cyan > .card-header .btn-tool,
+.bg-gradient-cyan > .card-header .btn-tool,
+.card-cyan:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-cyan .btn-tool:hover,
-.bg-gradient-cyan .btn-tool:hover,
-.card-cyan:not(.card-outline) .btn-tool:hover {
+.bg-cyan > .card-header .btn-tool:hover,
+.bg-gradient-cyan > .card-header .btn-tool:hover,
+.card-cyan:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18774,15 +28898,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #fff;
 }
 
-.bg-white .btn-tool,
-.bg-gradient-white .btn-tool,
-.card-white:not(.card-outline) .btn-tool {
+.bg-white > .card-header .btn-tool,
+.bg-gradient-white > .card-header .btn-tool,
+.card-white:not(.card-outline) > .card-header .btn-tool {
   color: rgba(31, 45, 61, 0.8);
 }
 
-.bg-white .btn-tool:hover,
-.bg-gradient-white .btn-tool:hover,
-.card-white:not(.card-outline) .btn-tool:hover {
+.bg-white > .card-header .btn-tool:hover,
+.bg-gradient-white > .card-header .btn-tool:hover,
+.card-white:not(.card-outline) > .card-header .btn-tool:hover {
   color: #1f2d3d;
 }
 
@@ -18845,15 +28969,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #6c757d;
 }
 
-.bg-gray .btn-tool,
-.bg-gradient-gray .btn-tool,
-.card-gray:not(.card-outline) .btn-tool {
+.bg-gray > .card-header .btn-tool,
+.bg-gradient-gray > .card-header .btn-tool,
+.card-gray:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-gray .btn-tool:hover,
-.bg-gradient-gray .btn-tool:hover,
-.card-gray:not(.card-outline) .btn-tool:hover {
+.bg-gray > .card-header .btn-tool:hover,
+.bg-gradient-gray > .card-header .btn-tool:hover,
+.card-gray:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18916,15 +29040,15 @@ body.text-sm .input-group-text {
   border-top: 3px solid #343a40;
 }
 
-.bg-gray-dark .btn-tool,
-.bg-gradient-gray-dark .btn-tool,
-.card-gray-dark:not(.card-outline) .btn-tool {
+.bg-gray-dark > .card-header .btn-tool,
+.bg-gradient-gray-dark > .card-header .btn-tool,
+.card-gray-dark:not(.card-outline) > .card-header .btn-tool {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.bg-gray-dark .btn-tool:hover,
-.bg-gradient-gray-dark .btn-tool:hover,
-.card-gray-dark:not(.card-outline) .btn-tool:hover {
+.bg-gray-dark > .card-header .btn-tool:hover,
+.bg-gradient-gray-dark > .card-header .btn-tool:hover,
+.card-gray-dark:not(.card-outline) > .card-header .btn-tool:hover {
   color: #fff;
 }
 
@@ -18995,7 +29119,7 @@ body.text-sm .input-group-text {
   overflow: auto;
 }
 
-.card.maximized-card [data-widget="collapse"] {
+.card.maximized-card [data-card-widgett="collapse"] {
   display: none;
 }
 
@@ -19456,6 +29580,1923 @@ html.maximized-card {
   border-left: 0;
 }
 
+.dark-mode .card-primary:not(.card-outline) > .card-header {
+  background-color: #3f6791;
+}
+
+.dark-mode .card-primary:not(.card-outline) > .card-header,
+.dark-mode .card-primary:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-primary:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-primary.card-outline {
+  border-top: 3px solid #3f6791;
+}
+
+.dark-mode .card-primary.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-primary.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3f6791;
+}
+
+.dark-mode .bg-primary > .card-header .btn-tool,
+.dark-mode .bg-gradient-primary > .card-header .btn-tool,
+.dark-mode .card-primary:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-primary > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-primary > .card-header .btn-tool:hover,
+.dark-mode .card-primary:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #335375;
+  color: #fff;
+}
+
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-primary .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #5080b3;
+  color: #fff;
+}
+
+.dark-mode .card-secondary:not(.card-outline) > .card-header {
+  background-color: #6c757d;
+}
+
+.dark-mode .card-secondary:not(.card-outline) > .card-header,
+.dark-mode .card-secondary:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-secondary:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-secondary.card-outline {
+  border-top: 3px solid #6c757d;
+}
+
+.dark-mode .card-secondary.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-secondary.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6c757d;
+}
+
+.dark-mode .bg-secondary > .card-header .btn-tool,
+.dark-mode .bg-gradient-secondary > .card-header .btn-tool,
+.dark-mode .card-secondary:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-secondary > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-secondary > .card-header .btn-tool:hover,
+.dark-mode .card-secondary:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #596167;
+  color: #fff;
+}
+
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-secondary .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #868e96;
+  color: #fff;
+}
+
+.dark-mode .card-success:not(.card-outline) > .card-header {
+  background-color: #00bc8c;
+}
+
+.dark-mode .card-success:not(.card-outline) > .card-header,
+.dark-mode .card-success:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-success:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-success.card-outline {
+  border-top: 3px solid #00bc8c;
+}
+
+.dark-mode .card-success.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-success.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #00bc8c;
+}
+
+.dark-mode .bg-success > .card-header .btn-tool,
+.dark-mode .bg-gradient-success > .card-header .btn-tool,
+.dark-mode .card-success:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-success > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-success > .card-header .btn-tool:hover,
+.dark-mode .card-success:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #00936e;
+  color: #fff;
+}
+
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-success .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #00efb2;
+  color: #fff;
+}
+
+.dark-mode .card-info:not(.card-outline) > .card-header {
+  background-color: #3498db;
+}
+
+.dark-mode .card-info:not(.card-outline) > .card-header,
+.dark-mode .card-info:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-info:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-info.card-outline {
+  border-top: 3px solid #3498db;
+}
+
+.dark-mode .card-info.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-info.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3498db;
+}
+
+.dark-mode .bg-info > .card-header .btn-tool,
+.dark-mode .bg-gradient-info > .card-header .btn-tool,
+.dark-mode .card-info:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-info > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-info > .card-header .btn-tool:hover,
+.dark-mode .card-info:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #2383c4;
+  color: #fff;
+}
+
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-info .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #5faee3;
+  color: #fff;
+}
+
+.dark-mode .card-warning:not(.card-outline) > .card-header {
+  background-color: #f39c12;
+}
+
+.dark-mode .card-warning:not(.card-outline) > .card-header,
+.dark-mode .card-warning:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-warning:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-warning.card-outline {
+  border-top: 3px solid #f39c12;
+}
+
+.dark-mode .card-warning.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-warning.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f39c12;
+}
+
+.dark-mode .bg-warning > .card-header .btn-tool,
+.dark-mode .bg-gradient-warning > .card-header .btn-tool,
+.dark-mode .card-warning:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-warning > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-warning > .card-header .btn-tool:hover,
+.dark-mode .card-warning:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #d2850b;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-warning .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #f5b043;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-danger:not(.card-outline) > .card-header {
+  background-color: #e74c3c;
+}
+
+.dark-mode .card-danger:not(.card-outline) > .card-header,
+.dark-mode .card-danger:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-danger:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-danger.card-outline {
+  border-top: 3px solid #e74c3c;
+}
+
+.dark-mode .card-danger.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-danger.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #e74c3c;
+}
+
+.dark-mode .bg-danger > .card-header .btn-tool,
+.dark-mode .bg-gradient-danger > .card-header .btn-tool,
+.dark-mode .card-danger:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-danger > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-danger > .card-header .btn-tool:hover,
+.dark-mode .card-danger:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #df2e1b;
+  color: #fff;
+}
+
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-danger .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #ed7669;
+  color: #fff;
+}
+
+.dark-mode .card-light:not(.card-outline) > .card-header {
+  background-color: #f8f9fa;
+}
+
+.dark-mode .card-light:not(.card-outline) > .card-header,
+.dark-mode .card-light:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-light:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-light.card-outline {
+  border-top: 3px solid #f8f9fa;
+}
+
+.dark-mode .card-light.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-light.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f8f9fa;
+}
+
+.dark-mode .bg-light > .card-header .btn-tool,
+.dark-mode .bg-gradient-light > .card-header .btn-tool,
+.dark-mode .card-light:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-light > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-light > .card-header .btn-tool:hover,
+.dark-mode .card-light:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #e0e5e9;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-light .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: white;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-dark:not(.card-outline) > .card-header {
+  background-color: #343a40;
+}
+
+.dark-mode .card-dark:not(.card-outline) > .card-header,
+.dark-mode .card-dark:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-dark:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-dark.card-outline {
+  border-top: 3px solid #343a40;
+}
+
+.dark-mode .card-dark.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-dark.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #343a40;
+}
+
+.dark-mode .bg-dark > .card-header .btn-tool,
+.dark-mode .bg-gradient-dark > .card-header .btn-tool,
+.dark-mode .card-dark:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-dark > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-dark > .card-header .btn-tool:hover,
+.dark-mode .card-dark:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #222629;
+  color: #fff;
+}
+
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-dark .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #4b545c;
+  color: #fff;
+}
+
+.dark-mode .card-lightblue:not(.card-outline) > .card-header {
+  background-color: #86bad8;
+}
+
+.dark-mode .card-lightblue:not(.card-outline) > .card-header,
+.dark-mode .card-lightblue:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-lightblue:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-lightblue.card-outline {
+  border-top: 3px solid #86bad8;
+}
+
+.dark-mode .card-lightblue.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-lightblue.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #86bad8;
+}
+
+.dark-mode .bg-lightblue > .card-header .btn-tool,
+.dark-mode .bg-gradient-lightblue > .card-header .btn-tool,
+.dark-mode .card-lightblue:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-lightblue > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-lightblue > .card-header .btn-tool:hover,
+.dark-mode .card-lightblue:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #67a8ce;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-lightblue .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #acd0e5;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-navy:not(.card-outline) > .card-header {
+  background-color: #002c59;
+}
+
+.dark-mode .card-navy:not(.card-outline) > .card-header,
+.dark-mode .card-navy:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-navy:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-navy.card-outline {
+  border-top: 3px solid #002c59;
+}
+
+.dark-mode .card-navy.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-navy.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #002c59;
+}
+
+.dark-mode .bg-navy > .card-header .btn-tool,
+.dark-mode .bg-gradient-navy > .card-header .btn-tool,
+.dark-mode .card-navy:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-navy > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-navy > .card-header .btn-tool:hover,
+.dark-mode .card-navy:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #001730;
+  color: #fff;
+}
+
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-navy .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #00458c;
+  color: #fff;
+}
+
+.dark-mode .card-olive:not(.card-outline) > .card-header {
+  background-color: #74c8a3;
+}
+
+.dark-mode .card-olive:not(.card-outline) > .card-header,
+.dark-mode .card-olive:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-olive:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-olive.card-outline {
+  border-top: 3px solid #74c8a3;
+}
+
+.dark-mode .card-olive.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-olive.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #74c8a3;
+}
+
+.dark-mode .bg-olive > .card-header .btn-tool,
+.dark-mode .bg-gradient-olive > .card-header .btn-tool,
+.dark-mode .card-olive:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-olive > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-olive > .card-header .btn-tool:hover,
+.dark-mode .card-olive:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #57bc8f;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-olive .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #99d6bb;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-lime:not(.card-outline) > .card-header {
+  background-color: #67ffa9;
+}
+
+.dark-mode .card-lime:not(.card-outline) > .card-header,
+.dark-mode .card-lime:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-lime:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-lime.card-outline {
+  border-top: 3px solid #67ffa9;
+}
+
+.dark-mode .card-lime.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-lime.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #67ffa9;
+}
+
+.dark-mode .bg-lime > .card-header .btn-tool,
+.dark-mode .bg-gradient-lime > .card-header .btn-tool,
+.dark-mode .card-lime:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-lime > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-lime > .card-header .btn-tool:hover,
+.dark-mode .card-lime:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #3eff92;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-lime .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #9affc6;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header {
+  background-color: #f672d8;
+}
+
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header,
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-fuchsia.card-outline {
+  border-top: 3px solid #f672d8;
+}
+
+.dark-mode .card-fuchsia.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-fuchsia.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f672d8;
+}
+
+.dark-mode .bg-fuchsia > .card-header .btn-tool,
+.dark-mode .bg-gradient-fuchsia > .card-header .btn-tool,
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-fuchsia > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-fuchsia > .card-header .btn-tool:hover,
+.dark-mode .card-fuchsia:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #f44cce;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #f9a2e5;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-maroon:not(.card-outline) > .card-header {
+  background-color: #ed6c9b;
+}
+
+.dark-mode .card-maroon:not(.card-outline) > .card-header,
+.dark-mode .card-maroon:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-maroon:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-maroon.card-outline {
+  border-top: 3px solid #ed6c9b;
+}
+
+.dark-mode .card-maroon.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-maroon.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #ed6c9b;
+}
+
+.dark-mode .bg-maroon > .card-header .btn-tool,
+.dark-mode .bg-gradient-maroon > .card-header .btn-tool,
+.dark-mode .card-maroon:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-maroon > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-maroon > .card-header .btn-tool:hover,
+.dark-mode .card-maroon:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #e84883;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-maroon .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #f29aba;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-blue:not(.card-outline) > .card-header {
+  background-color: #3f6791;
+}
+
+.dark-mode .card-blue:not(.card-outline) > .card-header,
+.dark-mode .card-blue:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-blue:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-blue.card-outline {
+  border-top: 3px solid #3f6791;
+}
+
+.dark-mode .card-blue.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-blue.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3f6791;
+}
+
+.dark-mode .bg-blue > .card-header .btn-tool,
+.dark-mode .bg-gradient-blue > .card-header .btn-tool,
+.dark-mode .card-blue:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-blue > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-blue > .card-header .btn-tool:hover,
+.dark-mode .card-blue:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #335375;
+  color: #fff;
+}
+
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-blue .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #5080b3;
+  color: #fff;
+}
+
+.dark-mode .card-indigo:not(.card-outline) > .card-header {
+  background-color: #6610f2;
+}
+
+.dark-mode .card-indigo:not(.card-outline) > .card-header,
+.dark-mode .card-indigo:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-indigo:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-indigo.card-outline {
+  border-top: 3px solid #6610f2;
+}
+
+.dark-mode .card-indigo.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-indigo.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6610f2;
+}
+
+.dark-mode .bg-indigo > .card-header .btn-tool,
+.dark-mode .bg-gradient-indigo > .card-header .btn-tool,
+.dark-mode .card-indigo:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-indigo > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-indigo > .card-header .btn-tool:hover,
+.dark-mode .card-indigo:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #550bce;
+  color: #fff;
+}
+
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-indigo .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #8540f5;
+  color: #fff;
+}
+
+.dark-mode .card-purple:not(.card-outline) > .card-header {
+  background-color: #6f42c1;
+}
+
+.dark-mode .card-purple:not(.card-outline) > .card-header,
+.dark-mode .card-purple:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-purple:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-purple.card-outline {
+  border-top: 3px solid #6f42c1;
+}
+
+.dark-mode .card-purple.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-purple.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6f42c1;
+}
+
+.dark-mode .bg-purple > .card-header .btn-tool,
+.dark-mode .bg-gradient-purple > .card-header .btn-tool,
+.dark-mode .card-purple:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-purple > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-purple > .card-header .btn-tool:hover,
+.dark-mode .card-purple:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #5d36a4;
+  color: #fff;
+}
+
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-purple .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #8c68ce;
+  color: #fff;
+}
+
+.dark-mode .card-pink:not(.card-outline) > .card-header {
+  background-color: #e83e8c;
+}
+
+.dark-mode .card-pink:not(.card-outline) > .card-header,
+.dark-mode .card-pink:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-pink:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-pink.card-outline {
+  border-top: 3px solid #e83e8c;
+}
+
+.dark-mode .card-pink.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-pink.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #e83e8c;
+}
+
+.dark-mode .bg-pink > .card-header .btn-tool,
+.dark-mode .bg-gradient-pink > .card-header .btn-tool,
+.dark-mode .card-pink:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-pink > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-pink > .card-header .btn-tool:hover,
+.dark-mode .card-pink:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #e21b76;
+  color: #fff;
+}
+
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-pink .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #ed6ca7;
+  color: #fff;
+}
+
+.dark-mode .card-red:not(.card-outline) > .card-header {
+  background-color: #e74c3c;
+}
+
+.dark-mode .card-red:not(.card-outline) > .card-header,
+.dark-mode .card-red:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-red:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-red.card-outline {
+  border-top: 3px solid #e74c3c;
+}
+
+.dark-mode .card-red.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-red.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #e74c3c;
+}
+
+.dark-mode .bg-red > .card-header .btn-tool,
+.dark-mode .bg-gradient-red > .card-header .btn-tool,
+.dark-mode .card-red:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-red > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-red > .card-header .btn-tool:hover,
+.dark-mode .card-red:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #df2e1b;
+  color: #fff;
+}
+
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-red .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #ed7669;
+  color: #fff;
+}
+
+.dark-mode .card-orange:not(.card-outline) > .card-header {
+  background-color: #fd7e14;
+}
+
+.dark-mode .card-orange:not(.card-outline) > .card-header,
+.dark-mode .card-orange:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-orange:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-orange.card-outline {
+  border-top: 3px solid #fd7e14;
+}
+
+.dark-mode .card-orange.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-orange.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #fd7e14;
+}
+
+.dark-mode .bg-orange > .card-header .btn-tool,
+.dark-mode .bg-gradient-orange > .card-header .btn-tool,
+.dark-mode .card-orange:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-orange > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-orange > .card-header .btn-tool:hover,
+.dark-mode .card-orange:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #e66a02;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-orange .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #fd9a47;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-yellow:not(.card-outline) > .card-header {
+  background-color: #f39c12;
+}
+
+.dark-mode .card-yellow:not(.card-outline) > .card-header,
+.dark-mode .card-yellow:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-yellow:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-yellow.card-outline {
+  border-top: 3px solid #f39c12;
+}
+
+.dark-mode .card-yellow.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-yellow.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f39c12;
+}
+
+.dark-mode .bg-yellow > .card-header .btn-tool,
+.dark-mode .bg-gradient-yellow > .card-header .btn-tool,
+.dark-mode .card-yellow:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-yellow > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-yellow > .card-header .btn-tool:hover,
+.dark-mode .card-yellow:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #d2850b;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-yellow .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #f5b043;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-green:not(.card-outline) > .card-header {
+  background-color: #00bc8c;
+}
+
+.dark-mode .card-green:not(.card-outline) > .card-header,
+.dark-mode .card-green:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-green:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-green.card-outline {
+  border-top: 3px solid #00bc8c;
+}
+
+.dark-mode .card-green.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-green.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #00bc8c;
+}
+
+.dark-mode .bg-green > .card-header .btn-tool,
+.dark-mode .bg-gradient-green > .card-header .btn-tool,
+.dark-mode .card-green:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-green > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-green > .card-header .btn-tool:hover,
+.dark-mode .card-green:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #00936e;
+  color: #fff;
+}
+
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-green .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #00efb2;
+  color: #fff;
+}
+
+.dark-mode .card-teal:not(.card-outline) > .card-header {
+  background-color: #20c997;
+}
+
+.dark-mode .card-teal:not(.card-outline) > .card-header,
+.dark-mode .card-teal:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-teal:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-teal.card-outline {
+  border-top: 3px solid #20c997;
+}
+
+.dark-mode .card-teal.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-teal.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #20c997;
+}
+
+.dark-mode .bg-teal > .card-header .btn-tool,
+.dark-mode .bg-gradient-teal > .card-header .btn-tool,
+.dark-mode .card-teal:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-teal > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-teal > .card-header .btn-tool:hover,
+.dark-mode .card-teal:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #1aa67d;
+  color: #fff;
+}
+
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-teal .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #3ce0af;
+  color: #fff;
+}
+
+.dark-mode .card-cyan:not(.card-outline) > .card-header {
+  background-color: #3498db;
+}
+
+.dark-mode .card-cyan:not(.card-outline) > .card-header,
+.dark-mode .card-cyan:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-cyan:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-cyan.card-outline {
+  border-top: 3px solid #3498db;
+}
+
+.dark-mode .card-cyan.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-cyan.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3498db;
+}
+
+.dark-mode .bg-cyan > .card-header .btn-tool,
+.dark-mode .bg-gradient-cyan > .card-header .btn-tool,
+.dark-mode .card-cyan:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-cyan > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-cyan > .card-header .btn-tool:hover,
+.dark-mode .card-cyan:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #2383c4;
+  color: #fff;
+}
+
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-cyan .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #5faee3;
+  color: #fff;
+}
+
+.dark-mode .card-white:not(.card-outline) > .card-header {
+  background-color: #fff;
+}
+
+.dark-mode .card-white:not(.card-outline) > .card-header,
+.dark-mode .card-white:not(.card-outline) > .card-header a {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-white:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-white.card-outline {
+  border-top: 3px solid #fff;
+}
+
+.dark-mode .card-white.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-white.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #fff;
+}
+
+.dark-mode .bg-white > .card-header .btn-tool,
+.dark-mode .bg-gradient-white > .card-header .btn-tool,
+.dark-mode .card-white:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.dark-mode .bg-white > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-white > .card-header .btn-tool:hover,
+.dark-mode .card-white:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #ebebeb;
+  color: #1f2d3d;
+}
+
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1f2d3d;
+}
+
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-white .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: white;
+  color: #1f2d3d;
+}
+
+.dark-mode .card-gray:not(.card-outline) > .card-header {
+  background-color: #6c757d;
+}
+
+.dark-mode .card-gray:not(.card-outline) > .card-header,
+.dark-mode .card-gray:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-gray:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-gray.card-outline {
+  border-top: 3px solid #6c757d;
+}
+
+.dark-mode .card-gray.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-gray.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6c757d;
+}
+
+.dark-mode .bg-gray > .card-header .btn-tool,
+.dark-mode .bg-gradient-gray > .card-header .btn-tool,
+.dark-mode .card-gray:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-gray > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-gray > .card-header .btn-tool:hover,
+.dark-mode .card-gray:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #596167;
+  color: #fff;
+}
+
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gray .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #868e96;
+  color: #fff;
+}
+
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header {
+  background-color: #343a40;
+}
+
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header,
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header a {
+  color: #fff;
+}
+
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header a.active {
+  color: #1f2d3d;
+}
+
+.dark-mode .card-gray-dark.card-outline {
+  border-top: 3px solid #343a40;
+}
+
+.dark-mode .card-gray-dark.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.dark-mode .card-gray-dark.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #343a40;
+}
+
+.dark-mode .bg-gray-dark > .card-header .btn-tool,
+.dark-mode .bg-gradient-gray-dark > .card-header .btn-tool,
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark-mode .bg-gray-dark > .card-header .btn-tool:hover,
+.dark-mode .bg-gradient-gray-dark > .card-header .btn-tool:hover,
+.dark-mode .card-gray-dark:not(.card-outline) > .card-header .btn-tool:hover {
+  color: #fff;
+}
+
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget .table th,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table td,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.second:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.second:hover {
+  background-color: #222629;
+  color: #fff;
+}
+
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.today::before,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #fff;
+}
+
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active:hover,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active,
+.dark-mode .card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active:hover {
+  background-color: #4b545c;
+  color: #fff;
+}
+
 .dark-mode .card {
   background-color: #343a40;
   color: #fff;
@@ -19476,6 +31517,7 @@ html.maximized-card {
 
 .dark-mode .card.card-outline-tabs .card-header a:hover {
   border-color: #6c757d;
+  border-bottom-color: transparent;
 }
 
 .dark-mode .card:not(.card-outline) > .card-header a.active {
@@ -19500,16 +31542,134 @@ html.maximized-card {
   color: #fff;
 }
 
+.dark-mode .todo-list .primary {
+  border-left-color: #3f6791;
+}
+
+.dark-mode .todo-list .secondary {
+  border-left-color: #6c757d;
+}
+
+.dark-mode .todo-list .success {
+  border-left-color: #00bc8c;
+}
+
+.dark-mode .todo-list .info {
+  border-left-color: #3498db;
+}
+
+.dark-mode .todo-list .warning {
+  border-left-color: #f39c12;
+}
+
+.dark-mode .todo-list .danger {
+  border-left-color: #e74c3c;
+}
+
+.dark-mode .todo-list .light {
+  border-left-color: #f8f9fa;
+}
+
+.dark-mode .todo-list .dark {
+  border-left-color: #343a40;
+}
+
+.dark-mode .todo-list .lightblue {
+  border-left-color: #86bad8;
+}
+
+.dark-mode .todo-list .navy {
+  border-left-color: #002c59;
+}
+
+.dark-mode .todo-list .olive {
+  border-left-color: #74c8a3;
+}
+
+.dark-mode .todo-list .lime {
+  border-left-color: #67ffa9;
+}
+
+.dark-mode .todo-list .fuchsia {
+  border-left-color: #f672d8;
+}
+
+.dark-mode .todo-list .maroon {
+  border-left-color: #ed6c9b;
+}
+
+.dark-mode .todo-list .blue {
+  border-left-color: #3f6791;
+}
+
+.dark-mode .todo-list .indigo {
+  border-left-color: #6610f2;
+}
+
+.dark-mode .todo-list .purple {
+  border-left-color: #6f42c1;
+}
+
+.dark-mode .todo-list .pink {
+  border-left-color: #e83e8c;
+}
+
+.dark-mode .todo-list .red {
+  border-left-color: #e74c3c;
+}
+
+.dark-mode .todo-list .orange {
+  border-left-color: #fd7e14;
+}
+
+.dark-mode .todo-list .yellow {
+  border-left-color: #f39c12;
+}
+
+.dark-mode .todo-list .green {
+  border-left-color: #00bc8c;
+}
+
+.dark-mode .todo-list .teal {
+  border-left-color: #20c997;
+}
+
+.dark-mode .todo-list .cyan {
+  border-left-color: #3498db;
+}
+
+.dark-mode .todo-list .white {
+  border-left-color: #fff;
+}
+
+.dark-mode .todo-list .gray {
+  border-left-color: #6c757d;
+}
+
+.dark-mode .todo-list .gray-dark {
+  border-left-color: #343a40;
+}
+
 .modal-dialog .overlay {
-  background-color: #000;
-  display: block;
-  height: 100%;
-  left: 0;
-  opacity: .7;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: absolute;
+  left: 0;
   top: 0;
-  width: 100%;
+  bottom: 0;
+  right: 0;
+  margin: -1px;
   z-index: 1052;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #666f76;
+  border-radius: 0.3rem;
 }
 
 .modal-content.bg-warning .modal-header,
@@ -19602,6 +31762,334 @@ html.maximized-card {
 .dark-mode .toast .toast-header {
   background-color: rgba(52, 58, 64, 0.7);
   color: #f8f9fa;
+}
+
+.dark-mode .toast.bg-primary {
+  background-color: rgba(63, 103, 145, 0.9) !important;
+}
+
+.dark-mode .toast.bg-primary .close, .dark-mode .toast.bg-primary .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-primary .toast-header {
+  background-color: rgba(63, 103, 145, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-secondary {
+  background-color: rgba(108, 117, 125, 0.9) !important;
+}
+
+.dark-mode .toast.bg-secondary .close, .dark-mode .toast.bg-secondary .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-secondary .toast-header {
+  background-color: rgba(108, 117, 125, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-success {
+  background-color: rgba(0, 188, 140, 0.9) !important;
+}
+
+.dark-mode .toast.bg-success .close, .dark-mode .toast.bg-success .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-success .toast-header {
+  background-color: rgba(0, 188, 140, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-info {
+  background-color: rgba(52, 152, 219, 0.9) !important;
+}
+
+.dark-mode .toast.bg-info .close, .dark-mode .toast.bg-info .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-info .toast-header {
+  background-color: rgba(52, 152, 219, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-warning {
+  background-color: rgba(243, 156, 18, 0.9) !important;
+}
+
+.dark-mode .toast.bg-warning .toast-header {
+  background-color: rgba(243, 156, 18, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-danger {
+  background-color: rgba(231, 76, 60, 0.9) !important;
+}
+
+.dark-mode .toast.bg-danger .close, .dark-mode .toast.bg-danger .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-danger .toast-header {
+  background-color: rgba(231, 76, 60, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-light {
+  background-color: rgba(248, 249, 250, 0.9) !important;
+}
+
+.dark-mode .toast.bg-light .toast-header {
+  background-color: rgba(248, 249, 250, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-dark {
+  background-color: rgba(52, 58, 64, 0.9) !important;
+}
+
+.dark-mode .toast.bg-dark .close, .dark-mode .toast.bg-dark .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-dark .toast-header {
+  background-color: rgba(52, 58, 64, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-lightblue {
+  background-color: rgba(134, 186, 216, 0.9) !important;
+}
+
+.dark-mode .toast.bg-lightblue .toast-header {
+  background-color: rgba(134, 186, 216, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-navy {
+  background-color: rgba(0, 44, 89, 0.9) !important;
+}
+
+.dark-mode .toast.bg-navy .close, .dark-mode .toast.bg-navy .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-navy .toast-header {
+  background-color: rgba(0, 44, 89, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-olive {
+  background-color: rgba(116, 200, 163, 0.9) !important;
+}
+
+.dark-mode .toast.bg-olive .toast-header {
+  background-color: rgba(116, 200, 163, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-lime {
+  background-color: rgba(103, 255, 169, 0.9) !important;
+}
+
+.dark-mode .toast.bg-lime .toast-header {
+  background-color: rgba(103, 255, 169, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-fuchsia {
+  background-color: rgba(246, 114, 216, 0.9) !important;
+}
+
+.dark-mode .toast.bg-fuchsia .toast-header {
+  background-color: rgba(246, 114, 216, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-maroon {
+  background-color: rgba(237, 108, 155, 0.9) !important;
+}
+
+.dark-mode .toast.bg-maroon .toast-header {
+  background-color: rgba(237, 108, 155, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-blue {
+  background-color: rgba(63, 103, 145, 0.9) !important;
+}
+
+.dark-mode .toast.bg-blue .close, .dark-mode .toast.bg-blue .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-blue .toast-header {
+  background-color: rgba(63, 103, 145, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-indigo {
+  background-color: rgba(102, 16, 242, 0.9) !important;
+}
+
+.dark-mode .toast.bg-indigo .close, .dark-mode .toast.bg-indigo .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-indigo .toast-header {
+  background-color: rgba(102, 16, 242, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-purple {
+  background-color: rgba(111, 66, 193, 0.9) !important;
+}
+
+.dark-mode .toast.bg-purple .close, .dark-mode .toast.bg-purple .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-purple .toast-header {
+  background-color: rgba(111, 66, 193, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-pink {
+  background-color: rgba(232, 62, 140, 0.9) !important;
+}
+
+.dark-mode .toast.bg-pink .close, .dark-mode .toast.bg-pink .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-pink .toast-header {
+  background-color: rgba(232, 62, 140, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-red {
+  background-color: rgba(231, 76, 60, 0.9) !important;
+}
+
+.dark-mode .toast.bg-red .close, .dark-mode .toast.bg-red .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-red .toast-header {
+  background-color: rgba(231, 76, 60, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-orange {
+  background-color: rgba(253, 126, 20, 0.9) !important;
+}
+
+.dark-mode .toast.bg-orange .toast-header {
+  background-color: rgba(253, 126, 20, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-yellow {
+  background-color: rgba(243, 156, 18, 0.9) !important;
+}
+
+.dark-mode .toast.bg-yellow .toast-header {
+  background-color: rgba(243, 156, 18, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-green {
+  background-color: rgba(0, 188, 140, 0.9) !important;
+}
+
+.dark-mode .toast.bg-green .close, .dark-mode .toast.bg-green .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-green .toast-header {
+  background-color: rgba(0, 188, 140, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-teal {
+  background-color: rgba(32, 201, 151, 0.9) !important;
+}
+
+.dark-mode .toast.bg-teal .close, .dark-mode .toast.bg-teal .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-teal .toast-header {
+  background-color: rgba(32, 201, 151, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-cyan {
+  background-color: rgba(52, 152, 219, 0.9) !important;
+}
+
+.dark-mode .toast.bg-cyan .close, .dark-mode .toast.bg-cyan .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-cyan .toast-header {
+  background-color: rgba(52, 152, 219, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-white {
+  background-color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.dark-mode .toast.bg-white .toast-header {
+  background-color: rgba(255, 255, 255, 0.85);
+  color: #1f2d3d;
+}
+
+.dark-mode .toast.bg-gray {
+  background-color: rgba(108, 117, 125, 0.9) !important;
+}
+
+.dark-mode .toast.bg-gray .close, .dark-mode .toast.bg-gray .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-gray .toast-header {
+  background-color: rgba(108, 117, 125, 0.85);
+  color: #fff;
+}
+
+.dark-mode .toast.bg-gray-dark {
+  background-color: rgba(52, 58, 64, 0.9) !important;
+}
+
+.dark-mode .toast.bg-gray-dark .close, .dark-mode .toast.bg-gray-dark .mailbox-attachment-close {
+  color: #fff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.dark-mode .toast.bg-gray-dark .toast-header {
+  background-color: rgba(52, 58, 64, 0.85);
+  color: #fff;
 }
 
 .toast.bg-primary {
@@ -20079,6 +32567,566 @@ html.maximized-card {
   border-color: #78828a;
 }
 
+.dark-mode .btn-primary {
+  color: #fff;
+  background-color: #3f6791;
+  border-color: #3f6791;
+  box-shadow: none;
+}
+
+.dark-mode .btn-primary:hover {
+  color: #fff;
+  background-color: #335476;
+  border-color: #304e6d;
+}
+
+.dark-mode .btn-primary:focus, .dark-mode .btn-primary.focus {
+  color: #fff;
+  background-color: #335476;
+  border-color: #304e6d;
+  box-shadow: 0 0 0 0 rgba(92, 126, 162, 0.5);
+}
+
+.dark-mode .btn-primary.disabled, .dark-mode .btn-primary:disabled {
+  color: #fff;
+  background-color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .btn-primary:not(:disabled):not(.disabled):active, .dark-mode .btn-primary:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-primary.dropdown-toggle {
+  color: #fff;
+  background-color: #304e6d;
+  border-color: #2c4765;
+}
+
+.dark-mode .btn-primary:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-primary:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-primary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(92, 126, 162, 0.5);
+}
+
+.dark-mode .btn-secondary {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+  box-shadow: none;
+}
+
+.dark-mode .btn-secondary:hover {
+  color: #fff;
+  background-color: #5a6268;
+  border-color: #545b62;
+}
+
+.dark-mode .btn-secondary:focus, .dark-mode .btn-secondary.focus {
+  color: #fff;
+  background-color: #5a6268;
+  border-color: #545b62;
+  box-shadow: 0 0 0 0 rgba(130, 138, 145, 0.5);
+}
+
+.dark-mode .btn-secondary.disabled, .dark-mode .btn-secondary:disabled {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .btn-secondary:not(:disabled):not(.disabled):active, .dark-mode .btn-secondary:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #545b62;
+  border-color: #4e555b;
+}
+
+.dark-mode .btn-secondary:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-secondary:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(130, 138, 145, 0.5);
+}
+
+.dark-mode .btn-success {
+  color: #fff;
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+  box-shadow: none;
+}
+
+.dark-mode .btn-success:hover {
+  color: #fff;
+  background-color: #009670;
+  border-color: #008966;
+}
+
+.dark-mode .btn-success:focus, .dark-mode .btn-success.focus {
+  color: #fff;
+  background-color: #009670;
+  border-color: #008966;
+  box-shadow: 0 0 0 0 rgba(38, 198, 157, 0.5);
+}
+
+.dark-mode .btn-success.disabled, .dark-mode .btn-success:disabled {
+  color: #fff;
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .btn-success:not(:disabled):not(.disabled):active, .dark-mode .btn-success:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-success.dropdown-toggle {
+  color: #fff;
+  background-color: #008966;
+  border-color: #007c5d;
+}
+
+.dark-mode .btn-success:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-success:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(38, 198, 157, 0.5);
+}
+
+.dark-mode .btn-info {
+  color: #fff;
+  background-color: #3498db;
+  border-color: #3498db;
+  box-shadow: none;
+}
+
+.dark-mode .btn-info:hover {
+  color: #fff;
+  background-color: #2384c6;
+  border-color: #217dbb;
+}
+
+.dark-mode .btn-info:focus, .dark-mode .btn-info.focus {
+  color: #fff;
+  background-color: #2384c6;
+  border-color: #217dbb;
+  box-shadow: 0 0 0 0 rgba(82, 167, 224, 0.5);
+}
+
+.dark-mode .btn-info.disabled, .dark-mode .btn-info:disabled {
+  color: #fff;
+  background-color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .btn-info:not(:disabled):not(.disabled):active, .dark-mode .btn-info:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-info.dropdown-toggle {
+  color: #fff;
+  background-color: #217dbb;
+  border-color: #1f76b0;
+}
+
+.dark-mode .btn-info:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-info:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(82, 167, 224, 0.5);
+}
+
+.dark-mode .btn-warning {
+  color: #1f2d3d;
+  background-color: #f39c12;
+  border-color: #f39c12;
+  box-shadow: none;
+}
+
+.dark-mode .btn-warning:hover {
+  color: #fff;
+  background-color: #d4860b;
+  border-color: #c87f0a;
+}
+
+.dark-mode .btn-warning:focus, .dark-mode .btn-warning.focus {
+  color: #fff;
+  background-color: #d4860b;
+  border-color: #c87f0a;
+  box-shadow: 0 0 0 0 rgba(211, 139, 24, 0.5);
+}
+
+.dark-mode .btn-warning.disabled, .dark-mode .btn-warning:disabled {
+  color: #1f2d3d;
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .btn-warning:not(:disabled):not(.disabled):active, .dark-mode .btn-warning:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-warning.dropdown-toggle {
+  color: #fff;
+  background-color: #c87f0a;
+  border-color: #bc770a;
+}
+
+.dark-mode .btn-warning:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-warning:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(211, 139, 24, 0.5);
+}
+
+.dark-mode .btn-danger {
+  color: #fff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  box-shadow: none;
+}
+
+.dark-mode .btn-danger:hover {
+  color: #fff;
+  background-color: #e12e1c;
+  border-color: #d62c1a;
+}
+
+.dark-mode .btn-danger:focus, .dark-mode .btn-danger.focus {
+  color: #fff;
+  background-color: #e12e1c;
+  border-color: #d62c1a;
+  box-shadow: 0 0 0 0 rgba(235, 103, 89, 0.5);
+}
+
+.dark-mode .btn-danger.disabled, .dark-mode .btn-danger:disabled {
+  color: #fff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .btn-danger:not(:disabled):not(.disabled):active, .dark-mode .btn-danger:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #d62c1a;
+  border-color: #ca2a19;
+}
+
+.dark-mode .btn-danger:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-danger:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(235, 103, 89, 0.5);
+}
+
+.dark-mode .btn-light {
+  color: #1f2d3d;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+  box-shadow: none;
+}
+
+.dark-mode .btn-light:hover {
+  color: #1f2d3d;
+  background-color: #e2e6ea;
+  border-color: #dae0e5;
+}
+
+.dark-mode .btn-light:focus, .dark-mode .btn-light.focus {
+  color: #1f2d3d;
+  background-color: #e2e6ea;
+  border-color: #dae0e5;
+  box-shadow: 0 0 0 0 rgba(215, 218, 222, 0.5);
+}
+
+.dark-mode .btn-light.disabled, .dark-mode .btn-light:disabled {
+  color: #1f2d3d;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+}
+
+.dark-mode .btn-light:not(:disabled):not(.disabled):active, .dark-mode .btn-light:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-light.dropdown-toggle {
+  color: #1f2d3d;
+  background-color: #dae0e5;
+  border-color: #d3d9df;
+}
+
+.dark-mode .btn-light:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-light:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(215, 218, 222, 0.5);
+}
+
+.dark-mode .btn-dark {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40;
+  box-shadow: none;
+}
+
+.dark-mode .btn-dark:hover {
+  color: #fff;
+  background-color: #23272b;
+  border-color: #1d2124;
+}
+
+.dark-mode .btn-dark:focus, .dark-mode .btn-dark.focus {
+  color: #fff;
+  background-color: #23272b;
+  border-color: #1d2124;
+  box-shadow: 0 0 0 0 rgba(82, 88, 93, 0.5);
+}
+
+.dark-mode .btn-dark.disabled, .dark-mode .btn-dark:disabled {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40;
+}
+
+.dark-mode .btn-dark:not(:disabled):not(.disabled):active, .dark-mode .btn-dark:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #1d2124;
+  border-color: #171a1d;
+}
+
+.dark-mode .btn-dark:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-dark:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(82, 88, 93, 0.5);
+}
+
+.dark-mode .btn-outline-primary {
+  color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .btn-outline-primary:hover {
+  color: #fff;
+  background-color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .btn-outline-primary:focus, .dark-mode .btn-outline-primary.focus {
+  box-shadow: 0 0 0 0 rgba(63, 103, 145, 0.5);
+}
+
+.dark-mode .btn-outline-primary.disabled, .dark-mode .btn-outline-primary:disabled {
+  color: #3f6791;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-primary:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-primary:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-primary.dropdown-toggle {
+  color: #fff;
+  background-color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .btn-outline-primary:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-primary:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-primary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(63, 103, 145, 0.5);
+}
+
+.dark-mode .btn-outline-secondary {
+  color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .btn-outline-secondary:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .btn-outline-secondary:focus, .dark-mode .btn-outline-secondary.focus {
+  box-shadow: 0 0 0 0 rgba(108, 117, 125, 0.5);
+}
+
+.dark-mode .btn-outline-secondary.disabled, .dark-mode .btn-outline-secondary:disabled {
+  color: #6c757d;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-secondary:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-secondary:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-secondary:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(108, 117, 125, 0.5);
+}
+
+.dark-mode .btn-outline-success {
+  color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .btn-outline-success:hover {
+  color: #fff;
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .btn-outline-success:focus, .dark-mode .btn-outline-success.focus {
+  box-shadow: 0 0 0 0 rgba(0, 188, 140, 0.5);
+}
+
+.dark-mode .btn-outline-success.disabled, .dark-mode .btn-outline-success:disabled {
+  color: #00bc8c;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-success:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-success:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-success.dropdown-toggle {
+  color: #fff;
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .btn-outline-success:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-success:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(0, 188, 140, 0.5);
+}
+
+.dark-mode .btn-outline-info {
+  color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .btn-outline-info:hover {
+  color: #fff;
+  background-color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .btn-outline-info:focus, .dark-mode .btn-outline-info.focus {
+  box-shadow: 0 0 0 0 rgba(52, 152, 219, 0.5);
+}
+
+.dark-mode .btn-outline-info.disabled, .dark-mode .btn-outline-info:disabled {
+  color: #3498db;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-info:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-info:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-info.dropdown-toggle {
+  color: #fff;
+  background-color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .btn-outline-info:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-info:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(52, 152, 219, 0.5);
+}
+
+.dark-mode .btn-outline-warning {
+  color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .btn-outline-warning:hover {
+  color: #1f2d3d;
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .btn-outline-warning:focus, .dark-mode .btn-outline-warning.focus {
+  box-shadow: 0 0 0 0 rgba(243, 156, 18, 0.5);
+}
+
+.dark-mode .btn-outline-warning.disabled, .dark-mode .btn-outline-warning:disabled {
+  color: #f39c12;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-warning:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-warning:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-warning.dropdown-toggle {
+  color: #1f2d3d;
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .btn-outline-warning:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-warning:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(243, 156, 18, 0.5);
+}
+
+.dark-mode .btn-outline-danger {
+  color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .btn-outline-danger:hover {
+  color: #fff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .btn-outline-danger:focus, .dark-mode .btn-outline-danger.focus {
+  box-shadow: 0 0 0 0 rgba(231, 76, 60, 0.5);
+}
+
+.dark-mode .btn-outline-danger.disabled, .dark-mode .btn-outline-danger:disabled {
+  color: #e74c3c;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-danger:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-danger:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .btn-outline-danger:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-danger:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(231, 76, 60, 0.5);
+}
+
+.dark-mode .btn-outline-light {
+  color: #f8f9fa;
+  border-color: #f8f9fa;
+}
+
+.dark-mode .btn-outline-light:hover {
+  color: #1f2d3d;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+}
+
+.dark-mode .btn-outline-light:focus, .dark-mode .btn-outline-light.focus {
+  box-shadow: 0 0 0 0 rgba(248, 249, 250, 0.5);
+}
+
+.dark-mode .btn-outline-light.disabled, .dark-mode .btn-outline-light:disabled {
+  color: #f8f9fa;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-light:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-light:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-light.dropdown-toggle {
+  color: #1f2d3d;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+}
+
+.dark-mode .btn-outline-light:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-light:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(248, 249, 250, 0.5);
+}
+
+.dark-mode .btn-outline-dark {
+  color: #343a40;
+  border-color: #343a40;
+}
+
+.dark-mode .btn-outline-dark:hover {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40;
+}
+
+.dark-mode .btn-outline-dark:focus, .dark-mode .btn-outline-dark.focus {
+  box-shadow: 0 0 0 0 rgba(52, 58, 64, 0.5);
+}
+
+.dark-mode .btn-outline-dark.disabled, .dark-mode .btn-outline-dark:disabled {
+  color: #343a40;
+  background-color: transparent;
+}
+
+.dark-mode .btn-outline-dark:not(:disabled):not(.disabled):active, .dark-mode .btn-outline-dark:not(:disabled):not(.disabled).active,
+.show > .dark-mode .btn-outline-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40;
+}
+
+.dark-mode .btn-outline-dark:not(:disabled):not(.disabled):active:focus, .dark-mode .btn-outline-dark:not(:disabled):not(.disabled).active:focus,
+.show > .dark-mode .btn-outline-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0 rgba(52, 58, 64, 0.5);
+}
+
 .callout {
   border-radius: 0.25rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
@@ -20119,6 +33167,22 @@ html.maximized-card {
 
 .dark-mode .callout {
   background-color: #3f474e;
+}
+
+.dark-mode .callout.callout-danger {
+  border-left-color: #ed7669;
+}
+
+.dark-mode .callout.callout-warning {
+  border-left-color: #f5b043;
+}
+
+.dark-mode .callout.callout-info {
+  border-left-color: #5faee3;
+}
+
+.dark-mode .callout.callout-success {
+  border-left-color: #00efb2;
 }
 
 .alert .icon {
@@ -20299,6 +33363,166 @@ html.maximized-card {
   color: #040505;
 }
 
+.dark-mode .alert-primary {
+  color: #fff;
+  background-color: #3f6791;
+  border-color: #375a7f;
+}
+
+.dark-mode .alert-default-primary {
+  color: #004085;
+  background-color: #cce5ff;
+  border-color: #b8daff;
+}
+
+.dark-mode .alert-default-primary hr {
+  border-top-color: #9fcdff;
+}
+
+.dark-mode .alert-default-primary .alert-link {
+  color: #002752;
+}
+
+.dark-mode .alert-secondary {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #60686f;
+}
+
+.dark-mode .alert-default-secondary {
+  color: #383d41;
+  background-color: #e2e3e5;
+  border-color: #d6d8db;
+}
+
+.dark-mode .alert-default-secondary hr {
+  border-top-color: #c8cbcf;
+}
+
+.dark-mode .alert-default-secondary .alert-link {
+  color: #202326;
+}
+
+.dark-mode .alert-success {
+  color: #fff;
+  background-color: #00bc8c;
+  border-color: #00a379;
+}
+
+.dark-mode .alert-default-success {
+  color: #155724;
+  background-color: #d4edda;
+  border-color: #c3e6cb;
+}
+
+.dark-mode .alert-default-success hr {
+  border-top-color: #b1dfbb;
+}
+
+.dark-mode .alert-default-success .alert-link {
+  color: #0b2e13;
+}
+
+.dark-mode .alert-info {
+  color: #fff;
+  background-color: #3498db;
+  border-color: #258cd1;
+}
+
+.dark-mode .alert-default-info {
+  color: #0c5460;
+  background-color: #d1ecf1;
+  border-color: #bee5eb;
+}
+
+.dark-mode .alert-default-info hr {
+  border-top-color: #abdde5;
+}
+
+.dark-mode .alert-default-info .alert-link {
+  color: #062c33;
+}
+
+.dark-mode .alert-warning {
+  color: #1f2d3d;
+  background-color: #f39c12;
+  border-color: #e08e0b;
+}
+
+.dark-mode .alert-default-warning {
+  color: #856404;
+  background-color: #fff3cd;
+  border-color: #ffeeba;
+}
+
+.dark-mode .alert-default-warning hr {
+  border-top-color: #ffe8a1;
+}
+
+.dark-mode .alert-default-warning .alert-link {
+  color: #533f03;
+}
+
+.dark-mode .alert-danger {
+  color: #fff;
+  background-color: #e74c3c;
+  border-color: #e43725;
+}
+
+.dark-mode .alert-default-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+
+.dark-mode .alert-default-danger hr {
+  border-top-color: #f1b0b7;
+}
+
+.dark-mode .alert-default-danger .alert-link {
+  color: #491217;
+}
+
+.dark-mode .alert-light {
+  color: #1f2d3d;
+  background-color: #f8f9fa;
+  border-color: #e9ecef;
+}
+
+.dark-mode .alert-default-light {
+  color: #818182;
+  background-color: #fefefe;
+  border-color: #fdfdfe;
+}
+
+.dark-mode .alert-default-light hr {
+  border-top-color: #ececf6;
+}
+
+.dark-mode .alert-default-light .alert-link {
+  color: #686868;
+}
+
+.dark-mode .alert-dark {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #292d32;
+}
+
+.dark-mode .alert-default-dark {
+  color: #1b1e21;
+  background-color: #d6d8d9;
+  border-color: #c6c8ca;
+}
+
+.dark-mode .alert-default-dark hr {
+  border-top-color: #b9bbbe;
+}
+
+.dark-mode .alert-default-dark .alert-link {
+  color: #040505;
+}
+
 .table:not(.table-dark) {
   color: inherit;
 }
@@ -20363,15 +33587,19 @@ html.maximized-card {
   cursor: pointer;
 }
 
-[data-widget="expandable-table"] i {
+[data-widget="expandable-table"] i.expandable-table-caret {
+  transition: -webkit-transform 0.3s linear;
   transition: transform 0.3s linear;
+  transition: transform 0.3s linear, -webkit-transform 0.3s linear;
 }
 
-[data-widget="expandable-table"][aria-expanded="true"] td > i[class*="right"] {
+[data-widget="expandable-table"][aria-expanded="true"] td i.expandable-table-caret[class*="right"] {
+  -webkit-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
-[data-widget="expandable-table"][aria-expanded="true"] td > i[class*="left"] {
+[data-widget="expandable-table"][aria-expanded="true"] td i.expandable-table-caret[class*="left"] {
+  -webkit-transform: rotate(-90deg);
   transform: rotate(-90deg);
 }
 
@@ -20565,7 +33793,9 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   position: absolute;
   right: 15px;
   top: 15px;
+  transition: -webkit-transform 0.3s linear;
   transition: transform 0.3s linear;
+  transition: transform 0.3s linear, -webkit-transform 0.3s linear;
 }
 
 .small-box .icon > i.fa, .small-box .icon > i.fas, .small-box .icon > i.far, .small-box .icon > i.fab, .small-box .icon > i.fal, .small-box .icon > i.fad, .small-box .icon > i.ion {
@@ -20578,7 +33808,9 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   position: absolute;
   right: 15px;
   top: 15px;
+  transition: -webkit-transform 0.3s linear;
   transition: transform 0.3s linear;
+  transition: transform 0.3s linear, -webkit-transform 0.3s linear;
 }
 
 .small-box:hover {
@@ -20586,10 +33818,12 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .small-box:hover .icon > i, .small-box:hover .icon > i.fa, .small-box:hover .icon > i.fas, .small-box:hover .icon > i.far, .small-box:hover .icon > i.fab, .small-box:hover .icon > i.fal, .small-box:hover .icon > i.fad, .small-box:hover .icon > i.ion {
+  -webkit-transform: scale(1.1);
   transform: scale(1.1);
 }
 
 .small-box:hover .icon > svg {
+  -webkit-transform: scale(1.1);
   transform: scale(1.1);
 }
 
@@ -20609,6 +33843,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.125), 0 1px 3px rgba(0, 0, 0, 0.2);
   border-radius: 0.25rem;
   background-color: #fff;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin-bottom: 1rem;
@@ -20630,11 +33865,14 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .info-box .info-box-icon {
   border-radius: 0.25rem;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   font-size: 1.875rem;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
@@ -20646,13 +33884,17 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .info-box .info-box-content {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.8;
+  -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   padding: 0 10px;
@@ -20806,6 +34048,86 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 .dark-mode .info-box {
   background-color: #343a40;
   color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-primary,
+.dark-mode .info-box .info-box .bg-gradient-primary {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-primary .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-primary .progress-bar {
+  background-color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-secondary,
+.dark-mode .info-box .info-box .bg-gradient-secondary {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-secondary .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-secondary .progress-bar {
+  background-color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-success,
+.dark-mode .info-box .info-box .bg-gradient-success {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-success .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-success .progress-bar {
+  background-color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-info,
+.dark-mode .info-box .info-box .bg-gradient-info {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-info .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-info .progress-bar {
+  background-color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-warning,
+.dark-mode .info-box .info-box .bg-gradient-warning {
+  color: #1f2d3d;
+}
+
+.dark-mode .info-box .info-box .bg-warning .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-warning .progress-bar {
+  background-color: #1f2d3d;
+}
+
+.dark-mode .info-box .info-box .bg-danger,
+.dark-mode .info-box .info-box .bg-gradient-danger {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-danger .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-danger .progress-bar {
+  background-color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-light,
+.dark-mode .info-box .info-box .bg-gradient-light {
+  color: #1f2d3d;
+}
+
+.dark-mode .info-box .info-box .bg-light .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-light .progress-bar {
+  background-color: #1f2d3d;
+}
+
+.dark-mode .info-box .info-box .bg-dark,
+.dark-mode .info-box .info-box .bg-gradient-dark {
+  color: #fff;
+}
+
+.dark-mode .info-box .info-box .bg-dark .progress-bar,
+.dark-mode .info-box .info-box .bg-gradient-dark .progress-bar {
+  background-color: #fff;
 }
 
 .timeline {
@@ -21018,6 +34340,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .direct-chat.chat-pane-open .direct-chat-contacts {
+  -webkit-transform: translate(0, 0);
   transform: translate(0, 0);
 }
 
@@ -21030,6 +34353,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .direct-chat-messages {
+  -webkit-transform: translate(0, 0);
   transform: translate(0, 0);
   height: 250px;
   overflow: auto;
@@ -21053,7 +34377,9 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .direct-chat-messages,
 .direct-chat-contacts {
+  transition: -webkit-transform .5s ease-in-out;
   transition: transform .5s ease-in-out;
+  transition: transform .5s ease-in-out, -webkit-transform .5s ease-in-out;
 }
 
 .direct-chat-text {
@@ -21126,10 +34452,12 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .direct-chat-contacts-open .direct-chat-contacts {
+  -webkit-transform: translate(0, 0);
   transform: translate(0, 0);
 }
 
 .direct-chat-contacts {
+  -webkit-transform: translate(101%, 0);
   transform: translate(101%, 0);
   background-color: #343a40;
   bottom: 0;
@@ -21499,6 +34827,276 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   border-right-color: transparent;
 }
 
+.dark-mode .direct-chat-primary .right > .direct-chat-text {
+  background-color: #3f6791;
+  border-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-primary .right > .direct-chat-text::after, .dark-mode .direct-chat-primary .right > .direct-chat-text::before {
+  border-left-color: #3f6791;
+}
+
+.dark-mode .direct-chat-secondary .right > .direct-chat-text {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-secondary .right > .direct-chat-text::after, .dark-mode .direct-chat-secondary .right > .direct-chat-text::before {
+  border-left-color: #6c757d;
+}
+
+.dark-mode .direct-chat-success .right > .direct-chat-text {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-success .right > .direct-chat-text::after, .dark-mode .direct-chat-success .right > .direct-chat-text::before {
+  border-left-color: #00bc8c;
+}
+
+.dark-mode .direct-chat-info .right > .direct-chat-text {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-info .right > .direct-chat-text::after, .dark-mode .direct-chat-info .right > .direct-chat-text::before {
+  border-left-color: #3498db;
+}
+
+.dark-mode .direct-chat-warning .right > .direct-chat-text {
+  background-color: #f39c12;
+  border-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-warning .right > .direct-chat-text::after, .dark-mode .direct-chat-warning .right > .direct-chat-text::before {
+  border-left-color: #f39c12;
+}
+
+.dark-mode .direct-chat-danger .right > .direct-chat-text {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-danger .right > .direct-chat-text::after, .dark-mode .direct-chat-danger .right > .direct-chat-text::before {
+  border-left-color: #e74c3c;
+}
+
+.dark-mode .direct-chat-light .right > .direct-chat-text {
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-light .right > .direct-chat-text::after, .dark-mode .direct-chat-light .right > .direct-chat-text::before {
+  border-left-color: #f8f9fa;
+}
+
+.dark-mode .direct-chat-dark .right > .direct-chat-text {
+  background-color: #343a40;
+  border-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-dark .right > .direct-chat-text::after, .dark-mode .direct-chat-dark .right > .direct-chat-text::before {
+  border-left-color: #343a40;
+}
+
+.dark-mode .direct-chat-lightblue .right > .direct-chat-text {
+  background-color: #86bad8;
+  border-color: #86bad8;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-lightblue .right > .direct-chat-text::after, .dark-mode .direct-chat-lightblue .right > .direct-chat-text::before {
+  border-left-color: #86bad8;
+}
+
+.dark-mode .direct-chat-navy .right > .direct-chat-text {
+  background-color: #002c59;
+  border-color: #002c59;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-navy .right > .direct-chat-text::after, .dark-mode .direct-chat-navy .right > .direct-chat-text::before {
+  border-left-color: #002c59;
+}
+
+.dark-mode .direct-chat-olive .right > .direct-chat-text {
+  background-color: #74c8a3;
+  border-color: #74c8a3;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-olive .right > .direct-chat-text::after, .dark-mode .direct-chat-olive .right > .direct-chat-text::before {
+  border-left-color: #74c8a3;
+}
+
+.dark-mode .direct-chat-lime .right > .direct-chat-text {
+  background-color: #67ffa9;
+  border-color: #67ffa9;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-lime .right > .direct-chat-text::after, .dark-mode .direct-chat-lime .right > .direct-chat-text::before {
+  border-left-color: #67ffa9;
+}
+
+.dark-mode .direct-chat-fuchsia .right > .direct-chat-text {
+  background-color: #f672d8;
+  border-color: #f672d8;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-fuchsia .right > .direct-chat-text::after, .dark-mode .direct-chat-fuchsia .right > .direct-chat-text::before {
+  border-left-color: #f672d8;
+}
+
+.dark-mode .direct-chat-maroon .right > .direct-chat-text {
+  background-color: #ed6c9b;
+  border-color: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-maroon .right > .direct-chat-text::after, .dark-mode .direct-chat-maroon .right > .direct-chat-text::before {
+  border-left-color: #ed6c9b;
+}
+
+.dark-mode .direct-chat-blue .right > .direct-chat-text {
+  background-color: #3f6791;
+  border-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-blue .right > .direct-chat-text::after, .dark-mode .direct-chat-blue .right > .direct-chat-text::before {
+  border-left-color: #3f6791;
+}
+
+.dark-mode .direct-chat-indigo .right > .direct-chat-text {
+  background-color: #6610f2;
+  border-color: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-indigo .right > .direct-chat-text::after, .dark-mode .direct-chat-indigo .right > .direct-chat-text::before {
+  border-left-color: #6610f2;
+}
+
+.dark-mode .direct-chat-purple .right > .direct-chat-text {
+  background-color: #6f42c1;
+  border-color: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-purple .right > .direct-chat-text::after, .dark-mode .direct-chat-purple .right > .direct-chat-text::before {
+  border-left-color: #6f42c1;
+}
+
+.dark-mode .direct-chat-pink .right > .direct-chat-text {
+  background-color: #e83e8c;
+  border-color: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-pink .right > .direct-chat-text::after, .dark-mode .direct-chat-pink .right > .direct-chat-text::before {
+  border-left-color: #e83e8c;
+}
+
+.dark-mode .direct-chat-red .right > .direct-chat-text {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-red .right > .direct-chat-text::after, .dark-mode .direct-chat-red .right > .direct-chat-text::before {
+  border-left-color: #e74c3c;
+}
+
+.dark-mode .direct-chat-orange .right > .direct-chat-text {
+  background-color: #fd7e14;
+  border-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-orange .right > .direct-chat-text::after, .dark-mode .direct-chat-orange .right > .direct-chat-text::before {
+  border-left-color: #fd7e14;
+}
+
+.dark-mode .direct-chat-yellow .right > .direct-chat-text {
+  background-color: #f39c12;
+  border-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-yellow .right > .direct-chat-text::after, .dark-mode .direct-chat-yellow .right > .direct-chat-text::before {
+  border-left-color: #f39c12;
+}
+
+.dark-mode .direct-chat-green .right > .direct-chat-text {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-green .right > .direct-chat-text::after, .dark-mode .direct-chat-green .right > .direct-chat-text::before {
+  border-left-color: #00bc8c;
+}
+
+.dark-mode .direct-chat-teal .right > .direct-chat-text {
+  background-color: #20c997;
+  border-color: #20c997;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-teal .right > .direct-chat-text::after, .dark-mode .direct-chat-teal .right > .direct-chat-text::before {
+  border-left-color: #20c997;
+}
+
+.dark-mode .direct-chat-cyan .right > .direct-chat-text {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-cyan .right > .direct-chat-text::after, .dark-mode .direct-chat-cyan .right > .direct-chat-text::before {
+  border-left-color: #3498db;
+}
+
+.dark-mode .direct-chat-white .right > .direct-chat-text {
+  background-color: #fff;
+  border-color: #fff;
+  color: #1f2d3d;
+}
+
+.dark-mode .direct-chat-white .right > .direct-chat-text::after, .dark-mode .direct-chat-white .right > .direct-chat-text::before {
+  border-left-color: #fff;
+}
+
+.dark-mode .direct-chat-gray .right > .direct-chat-text {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-gray .right > .direct-chat-text::after, .dark-mode .direct-chat-gray .right > .direct-chat-text::before {
+  border-left-color: #6c757d;
+}
+
+.dark-mode .direct-chat-gray-dark .right > .direct-chat-text {
+  background-color: #343a40;
+  border-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .direct-chat-gray-dark .right > .direct-chat-text::after, .dark-mode .direct-chat-gray-dark .right > .direct-chat-text::before {
+  border-left-color: #343a40;
+}
+
 .users-list {
   padding-left: 0;
   list-style: none;
@@ -21810,14 +35408,18 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 
 .login-page,
 .register-page {
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #e9ecef;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100vh;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
 }
@@ -22026,8 +35628,10 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 }
 
 .product-image-thumbs {
+  -webkit-align-items: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin-top: 2rem;
@@ -22038,6 +35642,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
   border-radius: 0.25rem;
   background-color: #fff;
   border: 1px solid #dee2e6;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin-right: 1rem;
@@ -22048,6 +35653,7 @@ a.close.disabled, a.disabled.mailbox-attachment-close {
 .product-image-thumb img {
   max-width: 100%;
   height: auto;
+  -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
@@ -22102,6 +35708,32 @@ body.iframe-mode-fullscreen {
   height: 100%;
 }
 
+.content-wrapper.iframe-mode .btn-iframe-close {
+  color: #dc3545;
+  position: absolute;
+  line-height: 1;
+  right: .125rem;
+  top: .125rem;
+  z-index: 10;
+  visibility: hidden;
+}
+
+.content-wrapper.iframe-mode .btn-iframe-close:hover, .content-wrapper.iframe-mode .btn-iframe-close:focus {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: visible;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .content-wrapper.iframe-mode .btn-iframe-close {
+    visibility: visible;
+  }
+}
+
 .content-wrapper.iframe-mode .navbar-nav {
   overflow-y: auto;
   width: 100%;
@@ -22111,16 +35743,43 @@ body.iframe-mode-fullscreen {
   white-space: nowrap;
 }
 
+.content-wrapper.iframe-mode .navbar-nav .nav-item {
+  position: relative;
+}
+
+.content-wrapper.iframe-mode .navbar-nav .nav-item:hover .btn-iframe-close, .content-wrapper.iframe-mode .navbar-nav .nav-item:focus .btn-iframe-close {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+  visibility: visible;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .content-wrapper.iframe-mode .navbar-nav .nav-item:hover .btn-iframe-close, .content-wrapper.iframe-mode .navbar-nav .nav-item:focus .btn-iframe-close {
+    visibility: visible;
+  }
+}
+
 .content-wrapper.iframe-mode .tab-content {
   position: relative;
 }
 
+.content-wrapper.iframe-mode .tab-pane + .tab-empty {
+  display: none;
+}
+
 .content-wrapper.iframe-mode .tab-empty {
   width: 100%;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
 }
@@ -22135,10 +35794,13 @@ body.iframe-mode-fullscreen {
 }
 
 .content-wrapper.iframe-mode .tab-loading > div {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
@@ -22149,6 +35811,7 @@ body.iframe-mode-fullscreen {
   border: 0;
   width: 100%;
   height: 100%;
+  margin-bottom: -8px;
 }
 
 .content-wrapper.iframe-mode iframe .content-wrapper {
@@ -22165,6 +35828,13 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
   height: 100%;
   min-height: 100%;
   z-index: 1048;
+}
+
+.permanent-btn-iframe-close .btn-iframe-close {
+  -webkit-animation: none !important;
+  animation: none !important;
+  visibility: visible !important;
+  opacity: 1;
 }
 
 .content-wrapper.kanban {
@@ -22186,8 +35856,10 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
 }
@@ -22211,8 +35883,13 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
 }
 
 .content-wrapper.kanban .card.card-row .card-body {
-  height: 100%;
+  height: calc(100% - (12px + (1.8rem * 1.2) + .5rem));
   overflow-y: auto;
+}
+
+.content-wrapper.kanban .card.card-row .card:last-child {
+  margin-bottom: 0;
+  border-bottom-width: 1px;
 }
 
 .content-wrapper.kanban .card.card-row .card .card-header {
@@ -22284,20 +35961,24 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
 
 @media (max-width: 575.98px) {
   .fc-toolbar {
+    -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
   }
   .fc-toolbar .fc-left {
+    -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
     margin-bottom: .5rem;
   }
   .fc-toolbar .fc-center {
+    -webkit-order: 0;
     -ms-flex-order: 0;
     order: 0;
     margin-bottom: .375rem;
   }
   .fc-toolbar .fc-right {
+    -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
   }
@@ -22330,7 +36011,9 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
 .fc-color-picker > li .fad,
 .fc-color-picker > li .svg-inline--fa,
 .fc-color-picker > li .ion {
+  transition: -webkit-transform linear .3s;
   transition: transform linear .3s;
+  transition: transform linear .3s, -webkit-transform linear .3s;
 }
 
 .fc-color-picker > li .fa:hover,
@@ -22341,6 +36024,7 @@ body.iframe-mode-fullscreen .content-wrapper.iframe-mode {
 .fc-color-picker > li .fad:hover,
 .fc-color-picker > li .svg-inline--fa:hover,
 .fc-color-picker > li .ion:hover {
+  -webkit-transform: rotate(30deg);
   transform: rotate(30deg);
 }
 
@@ -24154,6 +37838,1545 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
   color: #fff;
 }
 
+.dark-mode .select2-primary + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #85a7ca;
+}
+
+.dark-mode .select2-primary + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-primary.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-primary .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-primary .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-primary .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-primary .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-primary .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-results__option--highlighted,
+.dark-mode .select2-primary .select2-container--default .select2-results__option--highlighted {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-primary .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-primary .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-primary .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #3a5f86;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-selection--multiple:focus,
+.dark-mode .select2-primary .select2-container--default .select2-selection--multiple:focus {
+  border-color: #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-primary .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #3f6791;
+  border-color: #375a7f;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-primary .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-primary .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-primary .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-primary.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-primary .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #85a7ca;
+}
+
+.dark-mode .select2-secondary + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #afb5ba;
+}
+
+.dark-mode .select2-secondary + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-secondary.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-secondary .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-secondary .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-secondary .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-secondary .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-secondary .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-results__option--highlighted,
+.dark-mode .select2-secondary .select2-container--default .select2-results__option--highlighted {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-secondary .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-secondary .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-secondary .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #656d75;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-selection--multiple:focus,
+.dark-mode .select2-secondary .select2-container--default .select2-selection--multiple:focus {
+  border-color: #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-secondary .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #6c757d;
+  border-color: #60686f;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-secondary .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-secondary .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-secondary .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-secondary.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-secondary .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #afb5ba;
+}
+
+.dark-mode .select2-success + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #3dffcd;
+}
+
+.dark-mode .select2-success + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-success.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-success .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-success .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-success .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-success .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-success .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-success .select2-results__option--highlighted,
+.dark-mode .select2-success .select2-container--default .select2-results__option--highlighted {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-success .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-success .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-success .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-success .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #00ad81;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-success .select2-selection--multiple:focus,
+.dark-mode .select2-success .select2-container--default .select2-selection--multiple:focus {
+  border-color: #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-success .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-success .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #00bc8c;
+  border-color: #00a379;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-success .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-success .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-success .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-success .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-success.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-success .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #3dffcd;
+}
+
+.dark-mode .select2-info + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #a0cfee;
+}
+
+.dark-mode .select2-info + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-info.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-info .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-info .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-info .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-info .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-info .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-info .select2-results__option--highlighted,
+.dark-mode .select2-info .select2-container--default .select2-results__option--highlighted {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-info .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-info .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-info .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-info .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #2791d9;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-info .select2-selection--multiple:focus,
+.dark-mode .select2-info .select2-container--default .select2-selection--multiple:focus {
+  border-color: #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-info .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-info .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #3498db;
+  border-color: #258cd1;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-info .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-info .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-info .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-info .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-info.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-info .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #a0cfee;
+}
+
+.dark-mode .select2-warning + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .select2-warning + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-warning.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-warning .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-warning .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-warning .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-warning .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-warning .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-results__option--highlighted,
+.dark-mode .select2-warning .select2-container--default .select2-results__option--highlighted {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-warning .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-warning .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-warning .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #ea940c;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-selection--multiple:focus,
+.dark-mode .select2-warning .select2-container--default .select2-selection--multiple:focus {
+  border-color: #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-warning .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #f39c12;
+  border-color: #e08e0b;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-warning .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-warning .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-warning .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-warning.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-warning .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .select2-danger + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .select2-danger + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-danger.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-danger .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-danger .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-danger .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-danger .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-danger .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-results__option--highlighted,
+.dark-mode .select2-danger .select2-container--default .select2-results__option--highlighted {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-danger .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-danger .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-danger .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #e53f2e;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-selection--multiple:focus,
+.dark-mode .select2-danger .select2-container--default .select2-selection--multiple:focus {
+  border-color: #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-danger .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #e74c3c;
+  border-color: #e43725;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-danger .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-danger .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-danger .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-danger.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-danger .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .select2-light + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: white;
+}
+
+.dark-mode .select2-light + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: white;
+}
+
+.select2-container--default .dark-mode .select2-light.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-light .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-light .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-light .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-light .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-light .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid white;
+}
+
+.select2-container--default .dark-mode .select2-light .select2-results__option--highlighted,
+.dark-mode .select2-light .select2-container--default .select2-results__option--highlighted {
+  background-color: #f8f9fa;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-light .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-light .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-light .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-light .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #eff1f4;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-light .select2-selection--multiple:focus,
+.dark-mode .select2-light .select2-container--default .select2-selection--multiple:focus {
+  border-color: white;
+}
+
+.select2-container--default .dark-mode .select2-light .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-light .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #f8f9fa;
+  border-color: #e9ecef;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-light .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-light .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-light .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-light .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-light.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-light .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: white;
+}
+
+.dark-mode .select2-dark + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #6d7a86;
+}
+
+.dark-mode .select2-dark + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-dark.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-dark .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-dark .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-dark .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-dark .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-dark .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-results__option--highlighted,
+.dark-mode .select2-dark .select2-container--default .select2-results__option--highlighted {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-dark .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-dark .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-dark .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #2d3238;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-selection--multiple:focus,
+.dark-mode .select2-dark .select2-container--default .select2-selection--multiple:focus {
+  border-color: #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-dark .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #343a40;
+  border-color: #292d32;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-dark .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-dark .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-dark .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-dark.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-dark .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #6d7a86;
+}
+
+.dark-mode .select2-lightblue + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #e6f1f7;
+}
+
+.dark-mode .select2-lightblue + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #e6f1f7;
+}
+
+.select2-container--default .dark-mode .select2-lightblue.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-lightblue .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-lightblue .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-lightblue .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-lightblue .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-lightblue .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #e6f1f7;
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-results__option--highlighted,
+.dark-mode .select2-lightblue .select2-container--default .select2-results__option--highlighted {
+  background-color: #86bad8;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-lightblue .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-lightblue .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-lightblue .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #7ab3d5;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-selection--multiple:focus,
+.dark-mode .select2-lightblue .select2-container--default .select2-selection--multiple:focus {
+  border-color: #e6f1f7;
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #86bad8;
+  border-color: #72afd2;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-lightblue .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lightblue.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-lightblue .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #e6f1f7;
+}
+
+.dark-mode .select2-navy + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #006ad8;
+}
+
+.dark-mode .select2-navy + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #006ad8;
+}
+
+.select2-container--default .dark-mode .select2-navy.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-navy .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-navy .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-navy .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-navy .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-navy .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #006ad8;
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-results__option--highlighted,
+.dark-mode .select2-navy .select2-container--default .select2-results__option--highlighted {
+  background-color: #002c59;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-navy .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-navy .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-navy .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #002449;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-selection--multiple:focus,
+.dark-mode .select2-navy .select2-container--default .select2-selection--multiple:focus {
+  border-color: #006ad8;
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-navy .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #002c59;
+  border-color: #001f3f;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-navy .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-navy .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-navy .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-navy.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-navy .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #006ad8;
+}
+
+.dark-mode .select2-olive + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #cfecdf;
+}
+
+.dark-mode .select2-olive + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #cfecdf;
+}
+
+.select2-container--default .dark-mode .select2-olive.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-olive .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-olive .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-olive .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-olive .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-olive .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #cfecdf;
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-results__option--highlighted,
+.dark-mode .select2-olive .select2-container--default .select2-results__option--highlighted {
+  background-color: #74c8a3;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-olive .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-olive .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-olive .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #69c39b;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-selection--multiple:focus,
+.dark-mode .select2-olive .select2-container--default .select2-selection--multiple:focus {
+  border-color: #cfecdf;
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-olive .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #74c8a3;
+  border-color: #62c096;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-olive .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-olive .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-olive .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-olive.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-olive .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #cfecdf;
+}
+
+.dark-mode .select2-lime + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #e7fff1;
+}
+
+.dark-mode .select2-lime + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #e7fff1;
+}
+
+.select2-container--default .dark-mode .select2-lime.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-lime .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-lime .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-lime .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-lime .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-lime .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #e7fff1;
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-results__option--highlighted,
+.dark-mode .select2-lime .select2-container--default .select2-results__option--highlighted {
+  background-color: #67ffa9;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-lime .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-lime .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-lime .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #58ffa1;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-selection--multiple:focus,
+.dark-mode .select2-lime .select2-container--default .select2-selection--multiple:focus {
+  border-color: #e7fff1;
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-lime .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #67ffa9;
+  border-color: #4eff9b;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-lime .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-lime .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-lime .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-lime.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-lime .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #e7fff1;
+}
+
+.dark-mode .select2-fuchsia + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #feeaf9;
+}
+
+.dark-mode .select2-fuchsia + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #feeaf9;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-fuchsia .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-fuchsia .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-fuchsia .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-fuchsia .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-fuchsia .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #feeaf9;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-results__option--highlighted,
+.dark-mode .select2-fuchsia .select2-container--default .select2-results__option--highlighted {
+  background-color: #f672d8;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-fuchsia .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-fuchsia .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-fuchsia .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #f564d4;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-selection--multiple:focus,
+.dark-mode .select2-fuchsia .select2-container--default .select2-selection--multiple:focus {
+  border-color: #feeaf9;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-fuchsia .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #f672d8;
+  border-color: #f55ad2;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-fuchsia .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-fuchsia .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-fuchsia .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-fuchsia.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-fuchsia .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #feeaf9;
+}
+
+.dark-mode .select2-maroon + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #fbdee8;
+}
+
+.dark-mode .select2-maroon + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #fbdee8;
+}
+
+.select2-container--default .dark-mode .select2-maroon.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-maroon .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-maroon .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-maroon .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-maroon .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-maroon .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #fbdee8;
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-results__option--highlighted,
+.dark-mode .select2-maroon .select2-container--default .select2-results__option--highlighted {
+  background-color: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-maroon .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-maroon .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-maroon .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #eb5f92;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-selection--multiple:focus,
+.dark-mode .select2-maroon .select2-container--default .select2-selection--multiple:focus {
+  border-color: #fbdee8;
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-maroon .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #ed6c9b;
+  border-color: #ea568c;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-maroon .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-maroon .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-maroon .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-maroon.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-maroon .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #fbdee8;
+}
+
+.dark-mode .select2-blue + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #85a7ca;
+}
+
+.dark-mode .select2-blue + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-blue.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-blue .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-blue .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-blue .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-blue .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-blue .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-results__option--highlighted,
+.dark-mode .select2-blue .select2-container--default .select2-results__option--highlighted {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-blue .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-blue .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-blue .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #3a5f86;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-selection--multiple:focus,
+.dark-mode .select2-blue .select2-container--default .select2-selection--multiple:focus {
+  border-color: #85a7ca;
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-blue .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #3f6791;
+  border-color: #375a7f;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-blue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-blue .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-blue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-blue.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-blue .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #85a7ca;
+}
+
+.dark-mode .select2-indigo + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #b389f9;
+}
+
+.dark-mode .select2-indigo + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #b389f9;
+}
+
+.select2-container--default .dark-mode .select2-indigo.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-indigo .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-indigo .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-indigo .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-indigo .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-indigo .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #b389f9;
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-results__option--highlighted,
+.dark-mode .select2-indigo .select2-container--default .select2-results__option--highlighted {
+  background-color: #6610f2;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-indigo .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-indigo .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-indigo .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #5f0de6;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-selection--multiple:focus,
+.dark-mode .select2-indigo .select2-container--default .select2-selection--multiple:focus {
+  border-color: #b389f9;
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-indigo .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #6610f2;
+  border-color: #5b0cdd;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-indigo .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-indigo .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-indigo .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-indigo.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-indigo .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #b389f9;
+}
+
+.dark-mode .select2-purple + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #b8a2e0;
+}
+
+.dark-mode .select2-purple + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #b8a2e0;
+}
+
+.select2-container--default .dark-mode .select2-purple.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-purple .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-purple .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-purple .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-purple .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-purple .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #b8a2e0;
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-results__option--highlighted,
+.dark-mode .select2-purple .select2-container--default .select2-results__option--highlighted {
+  background-color: #6f42c1;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-purple .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-purple .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-purple .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #683cb8;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-selection--multiple:focus,
+.dark-mode .select2-purple .select2-container--default .select2-selection--multiple:focus {
+  border-color: #b8a2e0;
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-purple .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #6f42c1;
+  border-color: #643ab0;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-purple .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-purple .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-purple .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-purple.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-purple .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #b8a2e0;
+}
+
+.dark-mode .select2-pink + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #f6b0d0;
+}
+
+.dark-mode .select2-pink + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #f6b0d0;
+}
+
+.select2-container--default .dark-mode .select2-pink.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-pink .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-pink .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-pink .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-pink .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-pink .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #f6b0d0;
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-results__option--highlighted,
+.dark-mode .select2-pink .select2-container--default .select2-results__option--highlighted {
+  background-color: #e83e8c;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-pink .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-pink .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-pink .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #e63084;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-selection--multiple:focus,
+.dark-mode .select2-pink .select2-container--default .select2-selection--multiple:focus {
+  border-color: #f6b0d0;
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-pink .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #e83e8c;
+  border-color: #e5277e;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-pink .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-pink .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-pink .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-pink.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-pink .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #f6b0d0;
+}
+
+.dark-mode .select2-red + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .select2-red + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-red.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-red .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-red .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-red .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-red .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-red .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-red .select2-results__option--highlighted,
+.dark-mode .select2-red .select2-container--default .select2-results__option--highlighted {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-red .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-red .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-red .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-red .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #e53f2e;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-red .select2-selection--multiple:focus,
+.dark-mode .select2-red .select2-container--default .select2-selection--multiple:focus {
+  border-color: #f5b4ae;
+}
+
+.select2-container--default .dark-mode .select2-red .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-red .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #e74c3c;
+  border-color: #e43725;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-red .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-red .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-red .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-red .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-red.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-red .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .select2-orange + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #fec392;
+}
+
+.dark-mode .select2-orange + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #fec392;
+}
+
+.select2-container--default .dark-mode .select2-orange.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-orange .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-orange .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-orange .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-orange .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-orange .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #fec392;
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-results__option--highlighted,
+.dark-mode .select2-orange .select2-container--default .select2-results__option--highlighted {
+  background-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-orange .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-orange .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-orange .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #fd7605;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-selection--multiple:focus,
+.dark-mode .select2-orange .select2-container--default .select2-selection--multiple:focus {
+  border-color: #fec392;
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-orange .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #fd7e14;
+  border-color: #f57102;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-orange .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-orange .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-orange .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-orange.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-orange .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #fec392;
+}
+
+.dark-mode .select2-yellow + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .select2-yellow + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-yellow.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-yellow .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-yellow .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-yellow .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-yellow .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-yellow .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-results__option--highlighted,
+.dark-mode .select2-yellow .select2-container--default .select2-results__option--highlighted {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-yellow .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-yellow .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-yellow .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #ea940c;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-selection--multiple:focus,
+.dark-mode .select2-yellow .select2-container--default .select2-selection--multiple:focus {
+  border-color: #f9cf8b;
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-yellow .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #f39c12;
+  border-color: #e08e0b;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-yellow .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-yellow .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-yellow .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-yellow.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-yellow .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .select2-green + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #3dffcd;
+}
+
+.dark-mode .select2-green + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-green.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-green .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-green .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-green .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-green .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-green .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-green .select2-results__option--highlighted,
+.dark-mode .select2-green .select2-container--default .select2-results__option--highlighted {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-green .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-green .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-green .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-green .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #00ad81;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-green .select2-selection--multiple:focus,
+.dark-mode .select2-green .select2-container--default .select2-selection--multiple:focus {
+  border-color: #3dffcd;
+}
+
+.select2-container--default .dark-mode .select2-green .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-green .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #00bc8c;
+  border-color: #00a379;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-green .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-green .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-green .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-green .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-green.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-green .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #3dffcd;
+}
+
+.dark-mode .select2-teal + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #7eeaca;
+}
+
+.dark-mode .select2-teal + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #7eeaca;
+}
+
+.select2-container--default .dark-mode .select2-teal.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-teal .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-teal .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-teal .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-teal .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-teal .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #7eeaca;
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-results__option--highlighted,
+.dark-mode .select2-teal .select2-container--default .select2-results__option--highlighted {
+  background-color: #20c997;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-teal .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-teal .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-teal .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #1ebc8d;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-selection--multiple:focus,
+.dark-mode .select2-teal .select2-container--default .select2-selection--multiple:focus {
+  border-color: #7eeaca;
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-teal .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #20c997;
+  border-color: #1cb386;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-teal .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-teal .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-teal .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-teal.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-teal .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #7eeaca;
+}
+
+.dark-mode .select2-cyan + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #a0cfee;
+}
+
+.dark-mode .select2-cyan + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-cyan.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-cyan .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-cyan .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-cyan .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-cyan .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-cyan .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-results__option--highlighted,
+.dark-mode .select2-cyan .select2-container--default .select2-results__option--highlighted {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-cyan .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-cyan .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-cyan .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #2791d9;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-selection--multiple:focus,
+.dark-mode .select2-cyan .select2-container--default .select2-selection--multiple:focus {
+  border-color: #a0cfee;
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-cyan .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #3498db;
+  border-color: #258cd1;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-cyan .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-cyan .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-cyan .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-cyan.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-cyan .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #a0cfee;
+}
+
+.dark-mode .select2-white + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: white;
+}
+
+.dark-mode .select2-white + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: white;
+}
+
+.select2-container--default .dark-mode .select2-white.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-white .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-white .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-white .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-white .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-white .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid white;
+}
+
+.select2-container--default .dark-mode .select2-white .select2-results__option--highlighted,
+.dark-mode .select2-white .select2-container--default .select2-results__option--highlighted {
+  background-color: #fff;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-white .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-white .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-white .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-white .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #f7f7f7;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-white .select2-selection--multiple:focus,
+.dark-mode .select2-white .select2-container--default .select2-selection--multiple:focus {
+  border-color: white;
+}
+
+.select2-container--default .dark-mode .select2-white .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-white .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #fff;
+  border-color: #f2f2f2;
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-white .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-white .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(31, 45, 61, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-white .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-white .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #1f2d3d;
+}
+
+.select2-container--default .dark-mode .select2-white.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-white .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: white;
+}
+
+.dark-mode .select2-gray + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #afb5ba;
+}
+
+.dark-mode .select2-gray + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-gray.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-gray .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-gray .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-gray .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-gray .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-gray .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-results__option--highlighted,
+.dark-mode .select2-gray .select2-container--default .select2-results__option--highlighted {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-gray .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-gray .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-gray .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #656d75;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-selection--multiple:focus,
+.dark-mode .select2-gray .select2-container--default .select2-selection--multiple:focus {
+  border-color: #afb5ba;
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-gray .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #6c757d;
+  border-color: #60686f;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-gray .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-gray .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-gray .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-gray .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #afb5ba;
+}
+
+.dark-mode .select2-gray-dark + .select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #6d7a86;
+}
+
+.dark-mode .select2-gray-dark + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark.select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-gray-dark .select2-dropdown .select2-search__field:focus,
+.select2-container--default .dark-mode .select2-gray-dark .select2-search--inline .select2-search__field:focus,
+.dark-mode .select2-gray-dark .select2-container--default.select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-gray-dark .select2-container--default .select2-dropdown .select2-search__field:focus,
+.dark-mode .select2-gray-dark .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-results__option--highlighted,
+.dark-mode .select2-gray-dark .select2-container--default .select2-results__option--highlighted {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-results__option--highlighted[aria-selected], .select2-container--default .dark-mode .select2-gray-dark .select2-results__option--highlighted[aria-selected]:hover,
+.dark-mode .select2-gray-dark .select2-container--default .select2-results__option--highlighted[aria-selected],
+.dark-mode .select2-gray-dark .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #2d3238;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-selection--multiple:focus,
+.dark-mode .select2-gray-dark .select2-container--default .select2-selection--multiple:focus {
+  border-color: #6d7a86;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-selection--multiple .select2-selection__choice,
+.dark-mode .select2-gray-dark .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #343a40;
+  border-color: #292d32;
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-selection--multiple .select2-selection__choice__remove,
+.dark-mode .select2-gray-dark .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .dark-mode .select2-gray-dark .select2-selection--multiple .select2-selection__choice__remove:hover,
+.dark-mode .select2-gray-dark .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #fff;
+}
+
+.select2-container--default .dark-mode .select2-gray-dark.select2-container--focus .select2-selection--multiple,
+.dark-mode .select2-gray-dark .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #6d7a86;
+}
+
 .slider .tooltip.in {
   opacity: 0.9;
 }
@@ -24277,6 +39500,114 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
 .dark-mode .slider-track {
   background-color: #4b545c;
   background-image: none;
+}
+
+.dark-mode .slider-primary .slider .slider-selection {
+  background: #3f6791;
+}
+
+.dark-mode .slider-secondary .slider .slider-selection {
+  background: #6c757d;
+}
+
+.dark-mode .slider-success .slider .slider-selection {
+  background: #00bc8c;
+}
+
+.dark-mode .slider-info .slider .slider-selection {
+  background: #3498db;
+}
+
+.dark-mode .slider-warning .slider .slider-selection {
+  background: #f39c12;
+}
+
+.dark-mode .slider-danger .slider .slider-selection {
+  background: #e74c3c;
+}
+
+.dark-mode .slider-light .slider .slider-selection {
+  background: #f8f9fa;
+}
+
+.dark-mode .slider-dark .slider .slider-selection {
+  background: #343a40;
+}
+
+.dark-mode .slider-lightblue .slider .slider-selection {
+  background: #86bad8;
+}
+
+.dark-mode .slider-navy .slider .slider-selection {
+  background: #002c59;
+}
+
+.dark-mode .slider-olive .slider .slider-selection {
+  background: #74c8a3;
+}
+
+.dark-mode .slider-lime .slider .slider-selection {
+  background: #67ffa9;
+}
+
+.dark-mode .slider-fuchsia .slider .slider-selection {
+  background: #f672d8;
+}
+
+.dark-mode .slider-maroon .slider .slider-selection {
+  background: #ed6c9b;
+}
+
+.dark-mode .slider-blue .slider .slider-selection {
+  background: #3f6791;
+}
+
+.dark-mode .slider-indigo .slider .slider-selection {
+  background: #6610f2;
+}
+
+.dark-mode .slider-purple .slider .slider-selection {
+  background: #6f42c1;
+}
+
+.dark-mode .slider-pink .slider .slider-selection {
+  background: #e83e8c;
+}
+
+.dark-mode .slider-red .slider .slider-selection {
+  background: #e74c3c;
+}
+
+.dark-mode .slider-orange .slider .slider-selection {
+  background: #fd7e14;
+}
+
+.dark-mode .slider-yellow .slider .slider-selection {
+  background: #f39c12;
+}
+
+.dark-mode .slider-green .slider .slider-selection {
+  background: #00bc8c;
+}
+
+.dark-mode .slider-teal .slider .slider-selection {
+  background: #20c997;
+}
+
+.dark-mode .slider-cyan .slider .slider-selection {
+  background: #3498db;
+}
+
+.dark-mode .slider-white .slider .slider-selection {
+  background: #fff;
+}
+
+.dark-mode .slider-gray .slider .slider-selection {
+  background: #6c757d;
+}
+
+.dark-mode .slider-gray-dark .slider .slider-selection {
+  background: #343a40;
 }
 
 .icheck-primary > input:first-child:not(:checked):not(:disabled):hover + label::before,
@@ -24714,6 +40045,438 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
 .dark-mode [class*="icheck-"] > input:first-child:not(:checked) + input[type="hidden"] + label::before,
 .dark-mode [class*="icheck-"] > input:first-child:not(:checked) + label::before {
   border-color: #6c757d;
+}
+
+.dark-mode .icheck-primary > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-primary > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-primary > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-primary > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-primary > input:first-child:checked + label::before,
+.dark-mode .icheck-primary > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-secondary > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-secondary > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-secondary > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-secondary > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-secondary > input:first-child:checked + label::before,
+.dark-mode .icheck-secondary > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-success > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-success > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-success > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-success > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-success > input:first-child:checked + label::before,
+.dark-mode .icheck-success > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-info > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-info > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-info > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-info > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-info > input:first-child:checked + label::before,
+.dark-mode .icheck-info > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-warning > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-warning > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-warning > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-warning > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-warning > input:first-child:checked + label::before,
+.dark-mode .icheck-warning > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-danger > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-danger > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-danger > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-danger > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-danger > input:first-child:checked + label::before,
+.dark-mode .icheck-danger > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-light > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-light > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #f8f9fa;
+}
+
+.dark-mode .icheck-light > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-light > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #f8f9fa;
+}
+
+.dark-mode .icheck-light > input:first-child:checked + label::before,
+.dark-mode .icheck-light > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+}
+
+.dark-mode .icheck-dark > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-dark > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #343a40;
+}
+
+.dark-mode .icheck-dark > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-dark > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #343a40;
+}
+
+.dark-mode .icheck-dark > input:first-child:checked + label::before,
+.dark-mode .icheck-dark > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #343a40;
+  border-color: #343a40;
+}
+
+.dark-mode .icheck-lightblue > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-lightblue > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #86bad8;
+}
+
+.dark-mode .icheck-lightblue > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-lightblue > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #86bad8;
+}
+
+.dark-mode .icheck-lightblue > input:first-child:checked + label::before,
+.dark-mode .icheck-lightblue > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #86bad8;
+  border-color: #86bad8;
+}
+
+.dark-mode .icheck-navy > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-navy > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #002c59;
+}
+
+.dark-mode .icheck-navy > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-navy > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #002c59;
+}
+
+.dark-mode .icheck-navy > input:first-child:checked + label::before,
+.dark-mode .icheck-navy > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #002c59;
+  border-color: #002c59;
+}
+
+.dark-mode .icheck-olive > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-olive > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #74c8a3;
+}
+
+.dark-mode .icheck-olive > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-olive > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #74c8a3;
+}
+
+.dark-mode .icheck-olive > input:first-child:checked + label::before,
+.dark-mode .icheck-olive > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #74c8a3;
+  border-color: #74c8a3;
+}
+
+.dark-mode .icheck-lime > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-lime > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #67ffa9;
+}
+
+.dark-mode .icheck-lime > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-lime > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #67ffa9;
+}
+
+.dark-mode .icheck-lime > input:first-child:checked + label::before,
+.dark-mode .icheck-lime > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #67ffa9;
+  border-color: #67ffa9;
+}
+
+.dark-mode .icheck-fuchsia > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-fuchsia > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #f672d8;
+}
+
+.dark-mode .icheck-fuchsia > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-fuchsia > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #f672d8;
+}
+
+.dark-mode .icheck-fuchsia > input:first-child:checked + label::before,
+.dark-mode .icheck-fuchsia > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #f672d8;
+  border-color: #f672d8;
+}
+
+.dark-mode .icheck-maroon > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-maroon > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #ed6c9b;
+}
+
+.dark-mode .icheck-maroon > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-maroon > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #ed6c9b;
+}
+
+.dark-mode .icheck-maroon > input:first-child:checked + label::before,
+.dark-mode .icheck-maroon > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #ed6c9b;
+  border-color: #ed6c9b;
+}
+
+.dark-mode .icheck-blue > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-blue > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-blue > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-blue > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-blue > input:first-child:checked + label::before,
+.dark-mode .icheck-blue > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #3f6791;
+  border-color: #3f6791;
+}
+
+.dark-mode .icheck-indigo > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-indigo > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #6610f2;
+}
+
+.dark-mode .icheck-indigo > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-indigo > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #6610f2;
+}
+
+.dark-mode .icheck-indigo > input:first-child:checked + label::before,
+.dark-mode .icheck-indigo > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #6610f2;
+  border-color: #6610f2;
+}
+
+.dark-mode .icheck-purple > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-purple > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #6f42c1;
+}
+
+.dark-mode .icheck-purple > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-purple > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #6f42c1;
+}
+
+.dark-mode .icheck-purple > input:first-child:checked + label::before,
+.dark-mode .icheck-purple > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #6f42c1;
+  border-color: #6f42c1;
+}
+
+.dark-mode .icheck-pink > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-pink > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #e83e8c;
+}
+
+.dark-mode .icheck-pink > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-pink > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #e83e8c;
+}
+
+.dark-mode .icheck-pink > input:first-child:checked + label::before,
+.dark-mode .icheck-pink > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #e83e8c;
+  border-color: #e83e8c;
+}
+
+.dark-mode .icheck-red > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-red > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-red > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-red > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-red > input:first-child:checked + label::before,
+.dark-mode .icheck-red > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.dark-mode .icheck-orange > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-orange > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #fd7e14;
+}
+
+.dark-mode .icheck-orange > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-orange > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #fd7e14;
+}
+
+.dark-mode .icheck-orange > input:first-child:checked + label::before,
+.dark-mode .icheck-orange > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #fd7e14;
+  border-color: #fd7e14;
+}
+
+.dark-mode .icheck-yellow > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-yellow > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-yellow > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-yellow > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-yellow > input:first-child:checked + label::before,
+.dark-mode .icheck-yellow > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+
+.dark-mode .icheck-green > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-green > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-green > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-green > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-green > input:first-child:checked + label::before,
+.dark-mode .icheck-green > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+}
+
+.dark-mode .icheck-teal > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-teal > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #20c997;
+}
+
+.dark-mode .icheck-teal > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-teal > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #20c997;
+}
+
+.dark-mode .icheck-teal > input:first-child:checked + label::before,
+.dark-mode .icheck-teal > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #20c997;
+  border-color: #20c997;
+}
+
+.dark-mode .icheck-cyan > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-cyan > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-cyan > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-cyan > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-cyan > input:first-child:checked + label::before,
+.dark-mode .icheck-cyan > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #3498db;
+  border-color: #3498db;
+}
+
+.dark-mode .icheck-white > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-white > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #fff;
+}
+
+.dark-mode .icheck-white > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-white > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #fff;
+}
+
+.dark-mode .icheck-white > input:first-child:checked + label::before,
+.dark-mode .icheck-white > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #fff;
+  border-color: #fff;
+}
+
+.dark-mode .icheck-gray > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-gray > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-gray > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-gray > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-gray > input:first-child:checked + label::before,
+.dark-mode .icheck-gray > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.dark-mode .icheck-gray-dark > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.dark-mode .icheck-gray-dark > input:first-child:not(:checked):not(:disabled):hover + input[type="hidden"] + label::before {
+  border-color: #343a40;
+}
+
+.dark-mode .icheck-gray-dark > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.dark-mode .icheck-gray-dark > input:first-child:not(:checked):not(:disabled):focus + input[type="hidden"] + label::before {
+  border-color: #343a40;
+}
+
+.dark-mode .icheck-gray-dark > input:first-child:checked + label::before,
+.dark-mode .icheck-gray-dark > input:first-child:checked + input[type="hidden"] + label::before {
+  background-color: #343a40;
+  border-color: #343a40;
 }
 
 .mapael .map {
@@ -28460,6 +44223,7 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
   border-radius: 0.25rem;
   display: inline-block;
   top: 0;
+  -webkit-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
 }
 
@@ -28749,6 +44513,168 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
   background-color: #3a4047;
   color: #fff;
   border-color: #454d55;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-primary,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-primary {
+  background: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-secondary,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-secondary {
+  background: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-success,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-success {
+  background: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-info,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-info {
+  background: #3498db;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-warning,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-warning {
+  background: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-danger,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-danger {
+  background: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-light,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-light {
+  background: #f8f9fa;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-dark,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-dark {
+  background: #343a40;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-lightblue,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-lightblue {
+  background: #86bad8;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-navy,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-navy {
+  background: #002c59;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-olive,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-olive {
+  background: #74c8a3;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-lime,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-lime {
+  background: #67ffa9;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-fuchsia,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-fuchsia {
+  background: #f672d8;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-maroon,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-maroon {
+  background: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-blue,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-blue {
+  background: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-indigo,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-indigo {
+  background: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-purple,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-purple {
+  background: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-pink,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-pink {
+  background: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-red,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-red {
+  background: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-orange,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-orange {
+  background: #fd7e14;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-yellow,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-yellow {
+  background: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-green,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-green {
+  background: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-teal,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-teal {
+  background: #20c997;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-cyan,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-cyan {
+  background: #3498db;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-white,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-white {
+  background: #fff;
+  color: #1f2d3d;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-gray,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-gray {
+  background: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-gray-dark,
+.dark-mode .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-gray-dark {
+  background: #343a40;
+  color: #fff;
 }
 
 .jqstooltip {
@@ -29053,11 +44979,14 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
 .info-box .overlay,
 .small-box .overlay {
   border-radius: 0.25rem;
+  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: rgba(255, 255, 255, 0.7);
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   z-index: 50;
@@ -29147,6 +45076,7 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
 .tab-pane > .overlay-wrapper > .overlay {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+  -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   margin-top: -1.25rem;
@@ -29202,6 +45132,7 @@ select.form-control-sm ~ .select2-container--default .select2-selection--multipl
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
   text-transform: uppercase;
   top: 10px;
+  -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   width: 90px;
 }
@@ -29656,6 +45587,357 @@ blockquote.quote-gray-dark h6 {
   background-color: #3f474e;
 }
 
+.dark-mode blockquote.quote-primary {
+  border-color: #007bff;
+}
+
+.dark-mode blockquote.quote-primary h1,
+.dark-mode blockquote.quote-primary h2,
+.dark-mode blockquote.quote-primary h3,
+.dark-mode blockquote.quote-primary h4,
+.dark-mode blockquote.quote-primary h5,
+.dark-mode blockquote.quote-primary h6 {
+  color: #007bff;
+}
+
+.dark-mode blockquote.quote-secondary {
+  border-color: #6c757d;
+}
+
+.dark-mode blockquote.quote-secondary h1,
+.dark-mode blockquote.quote-secondary h2,
+.dark-mode blockquote.quote-secondary h3,
+.dark-mode blockquote.quote-secondary h4,
+.dark-mode blockquote.quote-secondary h5,
+.dark-mode blockquote.quote-secondary h6 {
+  color: #6c757d;
+}
+
+.dark-mode blockquote.quote-success {
+  border-color: #28a745;
+}
+
+.dark-mode blockquote.quote-success h1,
+.dark-mode blockquote.quote-success h2,
+.dark-mode blockquote.quote-success h3,
+.dark-mode blockquote.quote-success h4,
+.dark-mode blockquote.quote-success h5,
+.dark-mode blockquote.quote-success h6 {
+  color: #28a745;
+}
+
+.dark-mode blockquote.quote-info {
+  border-color: #17a2b8;
+}
+
+.dark-mode blockquote.quote-info h1,
+.dark-mode blockquote.quote-info h2,
+.dark-mode blockquote.quote-info h3,
+.dark-mode blockquote.quote-info h4,
+.dark-mode blockquote.quote-info h5,
+.dark-mode blockquote.quote-info h6 {
+  color: #17a2b8;
+}
+
+.dark-mode blockquote.quote-warning {
+  border-color: #ffc107;
+}
+
+.dark-mode blockquote.quote-warning h1,
+.dark-mode blockquote.quote-warning h2,
+.dark-mode blockquote.quote-warning h3,
+.dark-mode blockquote.quote-warning h4,
+.dark-mode blockquote.quote-warning h5,
+.dark-mode blockquote.quote-warning h6 {
+  color: #ffc107;
+}
+
+.dark-mode blockquote.quote-danger {
+  border-color: #dc3545;
+}
+
+.dark-mode blockquote.quote-danger h1,
+.dark-mode blockquote.quote-danger h2,
+.dark-mode blockquote.quote-danger h3,
+.dark-mode blockquote.quote-danger h4,
+.dark-mode blockquote.quote-danger h5,
+.dark-mode blockquote.quote-danger h6 {
+  color: #dc3545;
+}
+
+.dark-mode blockquote.quote-light {
+  border-color: #f8f9fa;
+}
+
+.dark-mode blockquote.quote-light h1,
+.dark-mode blockquote.quote-light h2,
+.dark-mode blockquote.quote-light h3,
+.dark-mode blockquote.quote-light h4,
+.dark-mode blockquote.quote-light h5,
+.dark-mode blockquote.quote-light h6 {
+  color: #f8f9fa;
+}
+
+.dark-mode blockquote.quote-dark {
+  border-color: #343a40;
+}
+
+.dark-mode blockquote.quote-dark h1,
+.dark-mode blockquote.quote-dark h2,
+.dark-mode blockquote.quote-dark h3,
+.dark-mode blockquote.quote-dark h4,
+.dark-mode blockquote.quote-dark h5,
+.dark-mode blockquote.quote-dark h6 {
+  color: #343a40;
+}
+
+.dark-mode blockquote.quote-lightblue {
+  border-color: #3c8dbc;
+}
+
+.dark-mode blockquote.quote-lightblue h1,
+.dark-mode blockquote.quote-lightblue h2,
+.dark-mode blockquote.quote-lightblue h3,
+.dark-mode blockquote.quote-lightblue h4,
+.dark-mode blockquote.quote-lightblue h5,
+.dark-mode blockquote.quote-lightblue h6 {
+  color: #3c8dbc;
+}
+
+.dark-mode blockquote.quote-navy {
+  border-color: #001f3f;
+}
+
+.dark-mode blockquote.quote-navy h1,
+.dark-mode blockquote.quote-navy h2,
+.dark-mode blockquote.quote-navy h3,
+.dark-mode blockquote.quote-navy h4,
+.dark-mode blockquote.quote-navy h5,
+.dark-mode blockquote.quote-navy h6 {
+  color: #001f3f;
+}
+
+.dark-mode blockquote.quote-olive {
+  border-color: #3d9970;
+}
+
+.dark-mode blockquote.quote-olive h1,
+.dark-mode blockquote.quote-olive h2,
+.dark-mode blockquote.quote-olive h3,
+.dark-mode blockquote.quote-olive h4,
+.dark-mode blockquote.quote-olive h5,
+.dark-mode blockquote.quote-olive h6 {
+  color: #3d9970;
+}
+
+.dark-mode blockquote.quote-lime {
+  border-color: #01ff70;
+}
+
+.dark-mode blockquote.quote-lime h1,
+.dark-mode blockquote.quote-lime h2,
+.dark-mode blockquote.quote-lime h3,
+.dark-mode blockquote.quote-lime h4,
+.dark-mode blockquote.quote-lime h5,
+.dark-mode blockquote.quote-lime h6 {
+  color: #01ff70;
+}
+
+.dark-mode blockquote.quote-fuchsia {
+  border-color: #f012be;
+}
+
+.dark-mode blockquote.quote-fuchsia h1,
+.dark-mode blockquote.quote-fuchsia h2,
+.dark-mode blockquote.quote-fuchsia h3,
+.dark-mode blockquote.quote-fuchsia h4,
+.dark-mode blockquote.quote-fuchsia h5,
+.dark-mode blockquote.quote-fuchsia h6 {
+  color: #f012be;
+}
+
+.dark-mode blockquote.quote-maroon {
+  border-color: #d81b60;
+}
+
+.dark-mode blockquote.quote-maroon h1,
+.dark-mode blockquote.quote-maroon h2,
+.dark-mode blockquote.quote-maroon h3,
+.dark-mode blockquote.quote-maroon h4,
+.dark-mode blockquote.quote-maroon h5,
+.dark-mode blockquote.quote-maroon h6 {
+  color: #d81b60;
+}
+
+.dark-mode blockquote.quote-blue {
+  border-color: #007bff;
+}
+
+.dark-mode blockquote.quote-blue h1,
+.dark-mode blockquote.quote-blue h2,
+.dark-mode blockquote.quote-blue h3,
+.dark-mode blockquote.quote-blue h4,
+.dark-mode blockquote.quote-blue h5,
+.dark-mode blockquote.quote-blue h6 {
+  color: #007bff;
+}
+
+.dark-mode blockquote.quote-indigo {
+  border-color: #6610f2;
+}
+
+.dark-mode blockquote.quote-indigo h1,
+.dark-mode blockquote.quote-indigo h2,
+.dark-mode blockquote.quote-indigo h3,
+.dark-mode blockquote.quote-indigo h4,
+.dark-mode blockquote.quote-indigo h5,
+.dark-mode blockquote.quote-indigo h6 {
+  color: #6610f2;
+}
+
+.dark-mode blockquote.quote-purple {
+  border-color: #6f42c1;
+}
+
+.dark-mode blockquote.quote-purple h1,
+.dark-mode blockquote.quote-purple h2,
+.dark-mode blockquote.quote-purple h3,
+.dark-mode blockquote.quote-purple h4,
+.dark-mode blockquote.quote-purple h5,
+.dark-mode blockquote.quote-purple h6 {
+  color: #6f42c1;
+}
+
+.dark-mode blockquote.quote-pink {
+  border-color: #e83e8c;
+}
+
+.dark-mode blockquote.quote-pink h1,
+.dark-mode blockquote.quote-pink h2,
+.dark-mode blockquote.quote-pink h3,
+.dark-mode blockquote.quote-pink h4,
+.dark-mode blockquote.quote-pink h5,
+.dark-mode blockquote.quote-pink h6 {
+  color: #e83e8c;
+}
+
+.dark-mode blockquote.quote-red {
+  border-color: #dc3545;
+}
+
+.dark-mode blockquote.quote-red h1,
+.dark-mode blockquote.quote-red h2,
+.dark-mode blockquote.quote-red h3,
+.dark-mode blockquote.quote-red h4,
+.dark-mode blockquote.quote-red h5,
+.dark-mode blockquote.quote-red h6 {
+  color: #dc3545;
+}
+
+.dark-mode blockquote.quote-orange {
+  border-color: #fd7e14;
+}
+
+.dark-mode blockquote.quote-orange h1,
+.dark-mode blockquote.quote-orange h2,
+.dark-mode blockquote.quote-orange h3,
+.dark-mode blockquote.quote-orange h4,
+.dark-mode blockquote.quote-orange h5,
+.dark-mode blockquote.quote-orange h6 {
+  color: #fd7e14;
+}
+
+.dark-mode blockquote.quote-yellow {
+  border-color: #ffc107;
+}
+
+.dark-mode blockquote.quote-yellow h1,
+.dark-mode blockquote.quote-yellow h2,
+.dark-mode blockquote.quote-yellow h3,
+.dark-mode blockquote.quote-yellow h4,
+.dark-mode blockquote.quote-yellow h5,
+.dark-mode blockquote.quote-yellow h6 {
+  color: #ffc107;
+}
+
+.dark-mode blockquote.quote-green {
+  border-color: #28a745;
+}
+
+.dark-mode blockquote.quote-green h1,
+.dark-mode blockquote.quote-green h2,
+.dark-mode blockquote.quote-green h3,
+.dark-mode blockquote.quote-green h4,
+.dark-mode blockquote.quote-green h5,
+.dark-mode blockquote.quote-green h6 {
+  color: #28a745;
+}
+
+.dark-mode blockquote.quote-teal {
+  border-color: #20c997;
+}
+
+.dark-mode blockquote.quote-teal h1,
+.dark-mode blockquote.quote-teal h2,
+.dark-mode blockquote.quote-teal h3,
+.dark-mode blockquote.quote-teal h4,
+.dark-mode blockquote.quote-teal h5,
+.dark-mode blockquote.quote-teal h6 {
+  color: #20c997;
+}
+
+.dark-mode blockquote.quote-cyan {
+  border-color: #17a2b8;
+}
+
+.dark-mode blockquote.quote-cyan h1,
+.dark-mode blockquote.quote-cyan h2,
+.dark-mode blockquote.quote-cyan h3,
+.dark-mode blockquote.quote-cyan h4,
+.dark-mode blockquote.quote-cyan h5,
+.dark-mode blockquote.quote-cyan h6 {
+  color: #17a2b8;
+}
+
+.dark-mode blockquote.quote-white {
+  border-color: #fff;
+}
+
+.dark-mode blockquote.quote-white h1,
+.dark-mode blockquote.quote-white h2,
+.dark-mode blockquote.quote-white h3,
+.dark-mode blockquote.quote-white h4,
+.dark-mode blockquote.quote-white h5,
+.dark-mode blockquote.quote-white h6 {
+  color: #fff;
+}
+
+.dark-mode blockquote.quote-gray {
+  border-color: #6c757d;
+}
+
+.dark-mode blockquote.quote-gray h1,
+.dark-mode blockquote.quote-gray h2,
+.dark-mode blockquote.quote-gray h3,
+.dark-mode blockquote.quote-gray h4,
+.dark-mode blockquote.quote-gray h5,
+.dark-mode blockquote.quote-gray h6 {
+  color: #6c757d;
+}
+
+.dark-mode blockquote.quote-gray-dark {
+  border-color: #343a40;
+}
+
+.dark-mode blockquote.quote-gray-dark h1,
+.dark-mode blockquote.quote-gray-dark h2,
+.dark-mode blockquote.quote-gray-dark h3,
+.dark-mode blockquote.quote-gray-dark h4,
+.dark-mode blockquote.quote-gray-dark h5,
+.dark-mode blockquote.quote-gray-dark h6 {
+  color: #343a40;
+}
+
 .dark-mode .close, .dark-mode .mailbox-attachment-close,
 .dark-mode .mailbox-attachment-close {
   color: #adb5bd;
@@ -29679,6 +45961,7 @@ blockquote.quote-gray-dark h6 {
   }
   .content-wrapper,
   .main-footer {
+    -webkit-transform: translate(0, 0);
     transform: translate(0, 0);
     margin-left: 0 !important;
     min-height: 0 !important;
@@ -29809,6 +46092,82 @@ blockquote.quote-gray-dark h6 {
 
 .dark-mode .text-muted {
   color: #adb5bd !important;
+}
+
+.dark-mode .text-lightblue {
+  color: #86bad8 !important;
+}
+
+.dark-mode .text-navy {
+  color: #002c59 !important;
+}
+
+.dark-mode .text-olive {
+  color: #74c8a3 !important;
+}
+
+.dark-mode .text-lime {
+  color: #67ffa9 !important;
+}
+
+.dark-mode .text-fuchsia {
+  color: #f672d8 !important;
+}
+
+.dark-mode .text-maroon {
+  color: #ed6c9b !important;
+}
+
+.dark-mode .text-blue {
+  color: #3f6791 !important;
+}
+
+.dark-mode .text-indigo {
+  color: #6610f2 !important;
+}
+
+.dark-mode .text-purple {
+  color: #6f42c1 !important;
+}
+
+.dark-mode .text-pink {
+  color: #e83e8c !important;
+}
+
+.dark-mode .text-red {
+  color: #e74c3c !important;
+}
+
+.dark-mode .text-orange {
+  color: #fd7e14 !important;
+}
+
+.dark-mode .text-yellow {
+  color: #f39c12 !important;
+}
+
+.dark-mode .text-green {
+  color: #00bc8c !important;
+}
+
+.dark-mode .text-teal {
+  color: #20c997 !important;
+}
+
+.dark-mode .text-cyan {
+  color: #3498db !important;
+}
+
+.dark-mode .text-white {
+  color: #fff !important;
+}
+
+.dark-mode .text-gray {
+  color: #6c757d !important;
+}
+
+.dark-mode .text-gray-dark {
+  color: #343a40 !important;
 }
 
 .elevation-0 {
@@ -31014,12 +47373,14 @@ a.text-muted:hover {
 }
 
 .accent-primary .btn-link,
-.accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-primary .nav-tabs .nav-link {
   color: #007bff;
 }
 
 .accent-primary .btn-link:hover,
-.accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-primary .nav-tabs .nav-link:hover {
   color: #0056b3;
 }
 
@@ -31083,12 +47444,14 @@ a.text-muted:hover {
 }
 
 .accent-secondary .btn-link,
-.accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-secondary .nav-tabs .nav-link {
   color: #6c757d;
 }
 
 .accent-secondary .btn-link:hover,
-.accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-secondary .nav-tabs .nav-link:hover {
   color: #494f54;
 }
 
@@ -31152,12 +47515,14 @@ a.text-muted:hover {
 }
 
 .accent-success .btn-link,
-.accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-success .nav-tabs .nav-link {
   color: #28a745;
 }
 
 .accent-success .btn-link:hover,
-.accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-success .nav-tabs .nav-link:hover {
   color: #19692c;
 }
 
@@ -31221,12 +47586,14 @@ a.text-muted:hover {
 }
 
 .accent-info .btn-link,
-.accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-info .nav-tabs .nav-link {
   color: #17a2b8;
 }
 
 .accent-info .btn-link:hover,
-.accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-info .nav-tabs .nav-link:hover {
   color: #0f6674;
 }
 
@@ -31290,12 +47657,14 @@ a.text-muted:hover {
 }
 
 .accent-warning .btn-link,
-.accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-warning .nav-tabs .nav-link {
   color: #ffc107;
 }
 
 .accent-warning .btn-link:hover,
-.accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-warning .nav-tabs .nav-link:hover {
   color: #ba8b00;
 }
 
@@ -31359,12 +47728,14 @@ a.text-muted:hover {
 }
 
 .accent-danger .btn-link,
-.accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-danger .nav-tabs .nav-link {
   color: #dc3545;
 }
 
 .accent-danger .btn-link:hover,
-.accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-danger .nav-tabs .nav-link:hover {
   color: #a71d2a;
 }
 
@@ -31428,12 +47799,14 @@ a.text-muted:hover {
 }
 
 .accent-light .btn-link,
-.accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-light .nav-tabs .nav-link {
   color: #f8f9fa;
 }
 
 .accent-light .btn-link:hover,
-.accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-light .nav-tabs .nav-link:hover {
   color: #cbd3da;
 }
 
@@ -31497,12 +47870,14 @@ a.text-muted:hover {
 }
 
 .accent-dark .btn-link,
-.accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-dark .nav-tabs .nav-link {
   color: #343a40;
 }
 
 .accent-dark .btn-link:hover,
-.accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-dark .nav-tabs .nav-link:hover {
   color: #121416;
 }
 
@@ -31566,12 +47941,14 @@ a.text-muted:hover {
 }
 
 .accent-lightblue .btn-link,
-.accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-lightblue .nav-tabs .nav-link {
   color: #3c8dbc;
 }
 
 .accent-lightblue .btn-link:hover,
-.accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-lightblue .nav-tabs .nav-link:hover {
   color: #296282;
 }
 
@@ -31635,12 +48012,14 @@ a.text-muted:hover {
 }
 
 .accent-navy .btn-link,
-.accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-navy .nav-tabs .nav-link {
   color: #001f3f;
 }
 
 .accent-navy .btn-link:hover,
-.accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-navy .nav-tabs .nav-link:hover {
   color: black;
 }
 
@@ -31704,12 +48083,14 @@ a.text-muted:hover {
 }
 
 .accent-olive .btn-link,
-.accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-olive .nav-tabs .nav-link {
   color: #3d9970;
 }
 
 .accent-olive .btn-link:hover,
-.accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-olive .nav-tabs .nav-link:hover {
   color: #276248;
 }
 
@@ -31773,12 +48154,14 @@ a.text-muted:hover {
 }
 
 .accent-lime .btn-link,
-.accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-lime .nav-tabs .nav-link {
   color: #01ff70;
 }
 
 .accent-lime .btn-link:hover,
-.accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-lime .nav-tabs .nav-link:hover {
   color: #00b44e;
 }
 
@@ -31842,12 +48225,14 @@ a.text-muted:hover {
 }
 
 .accent-fuchsia .btn-link,
-.accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-fuchsia .nav-tabs .nav-link {
   color: #f012be;
 }
 
 .accent-fuchsia .btn-link:hover,
-.accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-fuchsia .nav-tabs .nav-link:hover {
   color: #ab0b87;
 }
 
@@ -31911,12 +48296,14 @@ a.text-muted:hover {
 }
 
 .accent-maroon .btn-link,
-.accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-maroon .nav-tabs .nav-link {
   color: #d81b60;
 }
 
 .accent-maroon .btn-link:hover,
-.accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-maroon .nav-tabs .nav-link:hover {
   color: #941342;
 }
 
@@ -31980,12 +48367,14 @@ a.text-muted:hover {
 }
 
 .accent-blue .btn-link,
-.accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-blue .nav-tabs .nav-link {
   color: #007bff;
 }
 
 .accent-blue .btn-link:hover,
-.accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-blue .nav-tabs .nav-link:hover {
   color: #0056b3;
 }
 
@@ -32049,12 +48438,14 @@ a.text-muted:hover {
 }
 
 .accent-indigo .btn-link,
-.accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-indigo .nav-tabs .nav-link {
   color: #6610f2;
 }
 
 .accent-indigo .btn-link:hover,
-.accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-indigo .nav-tabs .nav-link:hover {
   color: #4709ac;
 }
 
@@ -32118,12 +48509,14 @@ a.text-muted:hover {
 }
 
 .accent-purple .btn-link,
-.accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-purple .nav-tabs .nav-link {
   color: #6f42c1;
 }
 
 .accent-purple .btn-link:hover,
-.accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-purple .nav-tabs .nav-link:hover {
   color: #4e2d89;
 }
 
@@ -32187,12 +48580,14 @@ a.text-muted:hover {
 }
 
 .accent-pink .btn-link,
-.accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-pink .nav-tabs .nav-link {
   color: #e83e8c;
 }
 
 .accent-pink .btn-link:hover,
-.accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-pink .nav-tabs .nav-link:hover {
   color: #c21766;
 }
 
@@ -32256,12 +48651,14 @@ a.text-muted:hover {
 }
 
 .accent-red .btn-link,
-.accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-red .nav-tabs .nav-link {
   color: #dc3545;
 }
 
 .accent-red .btn-link:hover,
-.accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-red .nav-tabs .nav-link:hover {
   color: #a71d2a;
 }
 
@@ -32325,12 +48722,14 @@ a.text-muted:hover {
 }
 
 .accent-orange .btn-link,
-.accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-orange .nav-tabs .nav-link {
   color: #fd7e14;
 }
 
 .accent-orange .btn-link:hover,
-.accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-orange .nav-tabs .nav-link:hover {
   color: #c35a02;
 }
 
@@ -32394,12 +48793,14 @@ a.text-muted:hover {
 }
 
 .accent-yellow .btn-link,
-.accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-yellow .nav-tabs .nav-link {
   color: #ffc107;
 }
 
 .accent-yellow .btn-link:hover,
-.accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-yellow .nav-tabs .nav-link:hover {
   color: #ba8b00;
 }
 
@@ -32463,12 +48864,14 @@ a.text-muted:hover {
 }
 
 .accent-green .btn-link,
-.accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-green .nav-tabs .nav-link {
   color: #28a745;
 }
 
 .accent-green .btn-link:hover,
-.accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-green .nav-tabs .nav-link:hover {
   color: #19692c;
 }
 
@@ -32532,12 +48935,14 @@ a.text-muted:hover {
 }
 
 .accent-teal .btn-link,
-.accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-teal .nav-tabs .nav-link {
   color: #20c997;
 }
 
 .accent-teal .btn-link:hover,
-.accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-teal .nav-tabs .nav-link:hover {
   color: #158765;
 }
 
@@ -32601,12 +49006,14 @@ a.text-muted:hover {
 }
 
 .accent-cyan .btn-link,
-.accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-cyan .nav-tabs .nav-link {
   color: #17a2b8;
 }
 
 .accent-cyan .btn-link:hover,
-.accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-cyan .nav-tabs .nav-link:hover {
   color: #0f6674;
 }
 
@@ -32670,12 +49077,14 @@ a.text-muted:hover {
 }
 
 .accent-white .btn-link,
-.accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-white .nav-tabs .nav-link {
   color: #fff;
 }
 
 .accent-white .btn-link:hover,
-.accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-white .nav-tabs .nav-link:hover {
   color: #d9d9d9;
 }
 
@@ -32739,12 +49148,14 @@ a.text-muted:hover {
 }
 
 .accent-gray .btn-link,
-.accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-gray .nav-tabs .nav-link {
   color: #6c757d;
 }
 
 .accent-gray .btn-link:hover,
-.accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-gray .nav-tabs .nav-link:hover {
   color: #494f54;
 }
 
@@ -32808,12 +49219,14 @@ a.text-muted:hover {
 }
 
 .accent-gray-dark .btn-link,
-.accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+.accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.accent-gray-dark .nav-tabs .nav-link {
   color: #343a40;
 }
 
 .accent-gray-dark .btn-link:hover,
-.accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+.accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.accent-gray-dark .nav-tabs .nav-link:hover {
   color: #121416;
 }
 
@@ -32918,5 +49331,3088 @@ a.text-muted:hover {
 .dark-mode .link-black,
 .dark-mode .link-dark {
   color: #ced4da;
+}
+
+.dark-mode .bg-primary {
+  background-color: #3f6791 !important;
+}
+
+.dark-mode .bg-primary,
+.dark-mode .bg-primary > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-primary.btn:hover {
+  border-color: #304e6d;
+  color: #ececec;
+}
+
+.dark-mode .bg-primary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-primary.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-primary.btn:active, .dark-mode .bg-primary.btn.active {
+  background-color: #304e6d !important;
+  border-color: #2c4765;
+  color: #fff;
+}
+
+.dark-mode .bg-secondary {
+  background-color: #6c757d !important;
+}
+
+.dark-mode .bg-secondary,
+.dark-mode .bg-secondary > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-secondary.btn:hover {
+  border-color: #545b62;
+  color: #ececec;
+}
+
+.dark-mode .bg-secondary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-secondary.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-secondary.btn:active, .dark-mode .bg-secondary.btn.active {
+  background-color: #545b62 !important;
+  border-color: #4e555b;
+  color: #fff;
+}
+
+.dark-mode .bg-success {
+  background-color: #00bc8c !important;
+}
+
+.dark-mode .bg-success,
+.dark-mode .bg-success > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-success.btn:hover {
+  border-color: #008966;
+  color: #ececec;
+}
+
+.dark-mode .bg-success.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-success.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-success.btn:active, .dark-mode .bg-success.btn.active {
+  background-color: #008966 !important;
+  border-color: #007c5d;
+  color: #fff;
+}
+
+.dark-mode .bg-info {
+  background-color: #3498db !important;
+}
+
+.dark-mode .bg-info,
+.dark-mode .bg-info > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-info.btn:hover {
+  border-color: #217dbb;
+  color: #ececec;
+}
+
+.dark-mode .bg-info.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-info.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-info.btn:active, .dark-mode .bg-info.btn.active {
+  background-color: #217dbb !important;
+  border-color: #1f76b0;
+  color: #fff;
+}
+
+.dark-mode .bg-warning {
+  background-color: #f39c12 !important;
+}
+
+.dark-mode .bg-warning,
+.dark-mode .bg-warning > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-warning.btn:hover {
+  border-color: #c87f0a;
+  color: #121a24;
+}
+
+.dark-mode .bg-warning.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-warning.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-warning.btn:active, .dark-mode .bg-warning.btn.active {
+  background-color: #c87f0a !important;
+  border-color: #bc770a;
+  color: #fff;
+}
+
+.dark-mode .bg-danger {
+  background-color: #e74c3c !important;
+}
+
+.dark-mode .bg-danger,
+.dark-mode .bg-danger > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-danger.btn:hover {
+  border-color: #d62c1a;
+  color: #ececec;
+}
+
+.dark-mode .bg-danger.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-danger.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-danger.btn:active, .dark-mode .bg-danger.btn.active {
+  background-color: #d62c1a !important;
+  border-color: #ca2a19;
+  color: #fff;
+}
+
+.dark-mode .bg-light {
+  background-color: #f8f9fa !important;
+}
+
+.dark-mode .bg-light,
+.dark-mode .bg-light > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-light.btn:hover {
+  border-color: #dae0e5;
+  color: #121a24;
+}
+
+.dark-mode .bg-light.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-light.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-light.btn:active, .dark-mode .bg-light.btn.active {
+  background-color: #dae0e5 !important;
+  border-color: #d3d9df;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-dark {
+  background-color: #343a40 !important;
+}
+
+.dark-mode .bg-dark,
+.dark-mode .bg-dark > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-dark.btn:hover {
+  border-color: #1d2124;
+  color: #ececec;
+}
+
+.dark-mode .bg-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-dark.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-dark.btn:active, .dark-mode .bg-dark.btn.active {
+  background-color: #1d2124 !important;
+  border-color: #171a1d;
+  color: #fff;
+}
+
+.dark-mode .bg-lightblue {
+  background-color: #86bad8 !important;
+}
+
+.dark-mode .bg-lightblue,
+.dark-mode .bg-lightblue > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-lightblue.btn:hover {
+  border-color: #5fa4cc;
+  color: #121a24;
+}
+
+.dark-mode .bg-lightblue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-lightblue.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-lightblue.btn:active, .dark-mode .bg-lightblue.btn.active {
+  background-color: #5fa4cc !important;
+  border-color: #559ec9;
+  color: #fff;
+}
+
+.dark-mode .bg-navy {
+  background-color: #002c59 !important;
+}
+
+.dark-mode .bg-navy,
+.dark-mode .bg-navy > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-navy.btn:hover {
+  border-color: #001226;
+  color: #ececec;
+}
+
+.dark-mode .bg-navy.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-navy.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-navy.btn:active, .dark-mode .bg-navy.btn.active {
+  background-color: #001226 !important;
+  border-color: #000c19;
+  color: #fff;
+}
+
+.dark-mode .bg-olive {
+  background-color: #74c8a3 !important;
+}
+
+.dark-mode .bg-olive,
+.dark-mode .bg-olive > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-olive.btn:hover {
+  border-color: #50b98a;
+  color: #121a24;
+}
+
+.dark-mode .bg-olive.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-olive.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-olive.btn:active, .dark-mode .bg-olive.btn.active {
+  background-color: #50b98a !important;
+  border-color: #48b484;
+  color: #fff;
+}
+
+.dark-mode .bg-lime {
+  background-color: #67ffa9 !important;
+}
+
+.dark-mode .bg-lime,
+.dark-mode .bg-lime > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-lime.btn:hover {
+  border-color: #34ff8d;
+  color: #121a24;
+}
+
+.dark-mode .bg-lime.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-lime.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-lime.btn:active, .dark-mode .bg-lime.btn.active {
+  background-color: #34ff8d !important;
+  border-color: #27ff86;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-fuchsia {
+  background-color: #f672d8 !important;
+}
+
+.dark-mode .bg-fuchsia,
+.dark-mode .bg-fuchsia > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-fuchsia.btn:hover {
+  border-color: #f342cb;
+  color: #121a24;
+}
+
+.dark-mode .bg-fuchsia.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-fuchsia.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-fuchsia.btn:active, .dark-mode .bg-fuchsia.btn.active {
+  background-color: #f342cb !important;
+  border-color: #f236c8;
+  color: #fff;
+}
+
+.dark-mode .bg-maroon {
+  background-color: #ed6c9b !important;
+}
+
+.dark-mode .bg-maroon,
+.dark-mode .bg-maroon > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-maroon.btn:hover {
+  border-color: #e73f7c;
+  color: #121a24;
+}
+
+.dark-mode .bg-maroon.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-maroon.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-maroon.btn:active, .dark-mode .bg-maroon.btn.active {
+  background-color: #e73f7c !important;
+  border-color: #e63475;
+  color: #fff;
+}
+
+.dark-mode .bg-blue {
+  background-color: #3f6791 !important;
+}
+
+.dark-mode .bg-blue,
+.dark-mode .bg-blue > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-blue.btn:hover {
+  border-color: #304e6d;
+  color: #ececec;
+}
+
+.dark-mode .bg-blue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-blue.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-blue.btn:active, .dark-mode .bg-blue.btn.active {
+  background-color: #304e6d !important;
+  border-color: #2c4765;
+  color: #fff;
+}
+
+.dark-mode .bg-indigo {
+  background-color: #6610f2 !important;
+}
+
+.dark-mode .bg-indigo,
+.dark-mode .bg-indigo > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-indigo.btn:hover {
+  border-color: #510bc4;
+  color: #ececec;
+}
+
+.dark-mode .bg-indigo.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-indigo.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-indigo.btn:active, .dark-mode .bg-indigo.btn.active {
+  background-color: #510bc4 !important;
+  border-color: #4c0ab8;
+  color: #fff;
+}
+
+.dark-mode .bg-purple {
+  background-color: #6f42c1 !important;
+}
+
+.dark-mode .bg-purple,
+.dark-mode .bg-purple > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-purple.btn:hover {
+  border-color: #59339d;
+  color: #ececec;
+}
+
+.dark-mode .bg-purple.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-purple.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-purple.btn:active, .dark-mode .bg-purple.btn.active {
+  background-color: #59339d !important;
+  border-color: #533093;
+  color: #fff;
+}
+
+.dark-mode .bg-pink {
+  background-color: #e83e8c !important;
+}
+
+.dark-mode .bg-pink,
+.dark-mode .bg-pink > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-pink.btn:hover {
+  border-color: #d91a72;
+  color: #ececec;
+}
+
+.dark-mode .bg-pink.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-pink.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-pink.btn:active, .dark-mode .bg-pink.btn.active {
+  background-color: #d91a72 !important;
+  border-color: #ce196c;
+  color: #fff;
+}
+
+.dark-mode .bg-red {
+  background-color: #e74c3c !important;
+}
+
+.dark-mode .bg-red,
+.dark-mode .bg-red > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-red.btn:hover {
+  border-color: #d62c1a;
+  color: #ececec;
+}
+
+.dark-mode .bg-red.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-red.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-red.btn:active, .dark-mode .bg-red.btn.active {
+  background-color: #d62c1a !important;
+  border-color: #ca2a19;
+  color: #fff;
+}
+
+.dark-mode .bg-orange {
+  background-color: #fd7e14 !important;
+}
+
+.dark-mode .bg-orange,
+.dark-mode .bg-orange > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-orange.btn:hover {
+  border-color: #dc6502;
+  color: #121a24;
+}
+
+.dark-mode .bg-orange.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-orange.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-orange.btn:active, .dark-mode .bg-orange.btn.active {
+  background-color: #dc6502 !important;
+  border-color: #cf5f02;
+  color: #fff;
+}
+
+.dark-mode .bg-yellow {
+  background-color: #f39c12 !important;
+}
+
+.dark-mode .bg-yellow,
+.dark-mode .bg-yellow > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-yellow.btn:hover {
+  border-color: #c87f0a;
+  color: #121a24;
+}
+
+.dark-mode .bg-yellow.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-yellow.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-yellow.btn:active, .dark-mode .bg-yellow.btn.active {
+  background-color: #c87f0a !important;
+  border-color: #bc770a;
+  color: #fff;
+}
+
+.dark-mode .bg-green {
+  background-color: #00bc8c !important;
+}
+
+.dark-mode .bg-green,
+.dark-mode .bg-green > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-green.btn:hover {
+  border-color: #008966;
+  color: #ececec;
+}
+
+.dark-mode .bg-green.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-green.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-green.btn:active, .dark-mode .bg-green.btn.active {
+  background-color: #008966 !important;
+  border-color: #007c5d;
+  color: #fff;
+}
+
+.dark-mode .bg-teal {
+  background-color: #20c997 !important;
+}
+
+.dark-mode .bg-teal,
+.dark-mode .bg-teal > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-teal.btn:hover {
+  border-color: #199d76;
+  color: #ececec;
+}
+
+.dark-mode .bg-teal.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-teal.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-teal.btn:active, .dark-mode .bg-teal.btn.active {
+  background-color: #199d76 !important;
+  border-color: #17926e;
+  color: #fff;
+}
+
+.dark-mode .bg-cyan {
+  background-color: #3498db !important;
+}
+
+.dark-mode .bg-cyan,
+.dark-mode .bg-cyan > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-cyan.btn:hover {
+  border-color: #217dbb;
+  color: #ececec;
+}
+
+.dark-mode .bg-cyan.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-cyan.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-cyan.btn:active, .dark-mode .bg-cyan.btn.active {
+  background-color: #217dbb !important;
+  border-color: #1f76b0;
+  color: #fff;
+}
+
+.dark-mode .bg-white {
+  background-color: #fff !important;
+}
+
+.dark-mode .bg-white,
+.dark-mode .bg-white > a {
+  color: #1f2d3d !important;
+}
+
+.dark-mode .bg-white.btn:hover {
+  border-color: #e6e6e6;
+  color: #121a24;
+}
+
+.dark-mode .bg-white.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-white.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-white.btn:active, .dark-mode .bg-white.btn.active {
+  background-color: #e6e6e6 !important;
+  border-color: #dfdfdf;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gray {
+  background-color: #6c757d !important;
+}
+
+.dark-mode .bg-gray,
+.dark-mode .bg-gray > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-gray.btn:hover {
+  border-color: #545b62;
+  color: #ececec;
+}
+
+.dark-mode .bg-gray.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gray.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gray.btn:active, .dark-mode .bg-gray.btn.active {
+  background-color: #545b62 !important;
+  border-color: #4e555b;
+  color: #fff;
+}
+
+.dark-mode .bg-gray-dark {
+  background-color: #343a40 !important;
+}
+
+.dark-mode .bg-gray-dark,
+.dark-mode .bg-gray-dark > a {
+  color: #fff !important;
+}
+
+.dark-mode .bg-gray-dark.btn:hover {
+  border-color: #1d2124;
+  color: #ececec;
+}
+
+.dark-mode .bg-gray-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gray-dark.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gray-dark.btn:active, .dark-mode .bg-gray-dark.btn.active {
+  background-color: #1d2124 !important;
+  border-color: #171a1d;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-primary {
+  background: #3f6791 linear-gradient(180deg, #5c7ea2, #3f6791) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-primary.btn.disabled, .dark-mode .bg-gradient-primary.btn:disabled, .dark-mode .bg-gradient-primary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-primary.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-primary.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-primary.btn:hover {
+  background: #3f6791 linear-gradient(180deg, #526e8b, #335476) repeat-x !important;
+  border-color: #304e6d;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-primary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-primary.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-primary.btn:active, .dark-mode .bg-gradient-primary.btn.active {
+  background: #3f6791 linear-gradient(180deg, #4f6883, #304e6d) repeat-x !important;
+  border-color: #2c4765;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-secondary {
+  background: #6c757d linear-gradient(180deg, #828a91, #6c757d) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-secondary.btn.disabled, .dark-mode .bg-gradient-secondary.btn:disabled, .dark-mode .bg-gradient-secondary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-secondary.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-secondary.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-secondary.btn:hover {
+  background: #6c757d linear-gradient(180deg, #73797f, #5a6268) repeat-x !important;
+  border-color: #545b62;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-secondary.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-secondary.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-secondary.btn:active, .dark-mode .bg-gradient-secondary.btn.active {
+  background: #6c757d linear-gradient(180deg, #6e7479, #545b62) repeat-x !important;
+  border-color: #4e555b;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-success {
+  background: #00bc8c linear-gradient(180deg, #26c69d, #00bc8c) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-success.btn.disabled, .dark-mode .bg-gradient-success.btn:disabled, .dark-mode .bg-gradient-success.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-success.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-success.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-success.btn:hover {
+  background: #00bc8c linear-gradient(180deg, #26a685, #009670) repeat-x !important;
+  border-color: #008966;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-success.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-success.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-success.btn:active, .dark-mode .bg-gradient-success.btn.active {
+  background: #00bc8c linear-gradient(180deg, #269b7d, #008966) repeat-x !important;
+  border-color: #007c5d;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-info {
+  background: #3498db linear-gradient(180deg, #52a7e0, #3498db) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-info.btn.disabled, .dark-mode .bg-gradient-info.btn:disabled, .dark-mode .bg-gradient-info.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-info.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-info.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-info.btn:hover {
+  background: #3498db linear-gradient(180deg, #4497ce, #2384c6) repeat-x !important;
+  border-color: #217dbb;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-info.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-info.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-info.btn:active, .dark-mode .bg-gradient-info.btn.active {
+  background: #3498db linear-gradient(180deg, #4291c5, #217dbb) repeat-x !important;
+  border-color: #1f76b0;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-warning {
+  background: #f39c12 linear-gradient(180deg, #f5ab36, #f39c12) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-warning.btn.disabled, .dark-mode .bg-gradient-warning.btn:disabled, .dark-mode .bg-gradient-warning.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-warning.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-warning.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-warning.btn:hover {
+  background: #f39c12 linear-gradient(180deg, #da982f, #d4860b) repeat-x !important;
+  border-color: #c87f0a;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-warning.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-warning.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-warning.btn:active, .dark-mode .bg-gradient-warning.btn.active {
+  background: #f39c12 linear-gradient(180deg, #d0922f, #c87f0a) repeat-x !important;
+  border-color: #bc770a;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-danger {
+  background: #e74c3c linear-gradient(180deg, #eb6759, #e74c3c) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-danger.btn.disabled, .dark-mode .bg-gradient-danger.btn:disabled, .dark-mode .bg-gradient-danger.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-danger.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-danger.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-danger.btn:hover {
+  background: #e74c3c linear-gradient(180deg, #e64d3e, #e12e1c) repeat-x !important;
+  border-color: #d62c1a;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-danger.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-danger.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-danger.btn:active, .dark-mode .bg-gradient-danger.btn.active {
+  background: #e74c3c linear-gradient(180deg, #dc4c3d, #d62c1a) repeat-x !important;
+  border-color: #ca2a19;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-light {
+  background: #f8f9fa linear-gradient(180deg, #f9fafb, #f8f9fa) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-light.btn.disabled, .dark-mode .bg-gradient-light.btn:disabled, .dark-mode .bg-gradient-light.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-light.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-light.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-light.btn:hover {
+  background: #f8f9fa linear-gradient(180deg, #e6eaed, #e2e6ea) repeat-x !important;
+  border-color: #dae0e5;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-light.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-light.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-light.btn:active, .dark-mode .bg-gradient-light.btn.active {
+  background: #f8f9fa linear-gradient(180deg, #e0e4e9, #dae0e5) repeat-x !important;
+  border-color: #d3d9df;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-dark {
+  background: #343a40 linear-gradient(180deg, #52585d, #343a40) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-dark.btn.disabled, .dark-mode .bg-gradient-dark.btn:disabled, .dark-mode .bg-gradient-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-dark.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-dark.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-dark.btn:hover {
+  background: #343a40 linear-gradient(180deg, #44474b, #23272b) repeat-x !important;
+  border-color: #1d2124;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-dark.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-dark.btn:active, .dark-mode .bg-gradient-dark.btn.active {
+  background: #343a40 linear-gradient(180deg, #3f4245, #1d2124) repeat-x !important;
+  border-color: #171a1d;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-lightblue {
+  background: #86bad8 linear-gradient(180deg, #98c4de, #86bad8) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-lightblue.btn.disabled, .dark-mode .bg-gradient-lightblue.btn:disabled, .dark-mode .bg-gradient-lightblue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-lightblue.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-lightblue.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-lightblue.btn:hover {
+  background: #86bad8 linear-gradient(180deg, #7fb6d6, #69a9cf) repeat-x !important;
+  border-color: #5fa4cc;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-lightblue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-lightblue.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-lightblue.btn:active, .dark-mode .bg-gradient-lightblue.btn.active {
+  background: #86bad8 linear-gradient(180deg, #77b2d4, #5fa4cc) repeat-x !important;
+  border-color: #559ec9;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-navy {
+  background: #002c59 linear-gradient(180deg, #264b71, #002c59) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-navy.btn.disabled, .dark-mode .bg-gradient-navy.btn:disabled, .dark-mode .bg-gradient-navy.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-navy.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-navy.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-navy.btn:hover {
+  background: #002c59 linear-gradient(180deg, #263b51, #001932) repeat-x !important;
+  border-color: #001226;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-navy.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-navy.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-navy.btn:active, .dark-mode .bg-gradient-navy.btn.active {
+  background: #002c59 linear-gradient(180deg, #263646, #001226) repeat-x !important;
+  border-color: #000c19;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-olive {
+  background: #74c8a3 linear-gradient(180deg, #89d0b0, #74c8a3) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-olive.btn.disabled, .dark-mode .bg-gradient-olive.btn:disabled, .dark-mode .bg-gradient-olive.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-olive.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-olive.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-olive.btn:hover {
+  background: #74c8a3 linear-gradient(180deg, #72c7a1, #59bd90) repeat-x !important;
+  border-color: #50b98a;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-olive.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-olive.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-olive.btn:active, .dark-mode .bg-gradient-olive.btn.active {
+  background: #74c8a3 linear-gradient(180deg, #6ac49c, #50b98a) repeat-x !important;
+  border-color: #48b484;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-lime {
+  background: #67ffa9 linear-gradient(180deg, #7effb6, #67ffa9) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-lime.btn.disabled, .dark-mode .bg-gradient-lime.btn:disabled, .dark-mode .bg-gradient-lime.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-lime.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-lime.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-lime.btn:hover {
+  background: #67ffa9 linear-gradient(180deg, #5dffa4, #41ff94) repeat-x !important;
+  border-color: #34ff8d;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-lime.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-lime.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-lime.btn:active, .dark-mode .bg-gradient-lime.btn.active {
+  background: #67ffa9 linear-gradient(180deg, #52ff9e, #34ff8d) repeat-x !important;
+  border-color: #27ff86;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-fuchsia {
+  background: #f672d8 linear-gradient(180deg, #f787de, #f672d8) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-fuchsia.btn.disabled, .dark-mode .bg-gradient-fuchsia.btn:disabled, .dark-mode .bg-gradient-fuchsia.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-fuchsia.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-fuchsia.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-fuchsia.btn:hover {
+  background: #f672d8 linear-gradient(180deg, #f569d6, #f44ece) repeat-x !important;
+  border-color: #f342cb;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-fuchsia.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-fuchsia.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-fuchsia.btn:active, .dark-mode .bg-gradient-fuchsia.btn.active {
+  background: #f672d8 linear-gradient(180deg, #f55ed3, #f342cb) repeat-x !important;
+  border-color: #f236c8;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-maroon {
+  background: #ed6c9b linear-gradient(180deg, #ef82aa, #ed6c9b) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-maroon.btn.disabled, .dark-mode .bg-gradient-maroon.btn:disabled, .dark-mode .bg-gradient-maroon.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-maroon.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-maroon.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-maroon.btn:hover {
+  background: #ed6c9b linear-gradient(180deg, #ec6596, #e84a84) repeat-x !important;
+  border-color: #e73f7c;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-maroon.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-maroon.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-maroon.btn:active, .dark-mode .bg-gradient-maroon.btn.active {
+  background: #ed6c9b linear-gradient(180deg, #eb5c90, #e73f7c) repeat-x !important;
+  border-color: #e63475;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-blue {
+  background: #3f6791 linear-gradient(180deg, #5c7ea2, #3f6791) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-blue.btn.disabled, .dark-mode .bg-gradient-blue.btn:disabled, .dark-mode .bg-gradient-blue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-blue.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-blue.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-blue.btn:hover {
+  background: #3f6791 linear-gradient(180deg, #526e8b, #335476) repeat-x !important;
+  border-color: #304e6d;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-blue.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-blue.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-blue.btn:active, .dark-mode .bg-gradient-blue.btn.active {
+  background: #3f6791 linear-gradient(180deg, #4f6883, #304e6d) repeat-x !important;
+  border-color: #2c4765;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-indigo {
+  background: #6610f2 linear-gradient(180deg, #7d34f4, #6610f2) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-indigo.btn.disabled, .dark-mode .bg-gradient-indigo.btn:disabled, .dark-mode .bg-gradient-indigo.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-indigo.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-indigo.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-indigo.btn:hover {
+  background: #6610f2 linear-gradient(180deg, #7030d7, #560bd0) repeat-x !important;
+  border-color: #510bc4;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-indigo.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-indigo.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-indigo.btn:active, .dark-mode .bg-gradient-indigo.btn.active {
+  background: #6610f2 linear-gradient(180deg, #6b2fcd, #510bc4) repeat-x !important;
+  border-color: #4c0ab8;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-purple {
+  background: #6f42c1 linear-gradient(180deg, #855eca, #6f42c1) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-purple.btn.disabled, .dark-mode .bg-gradient-purple.btn:disabled, .dark-mode .bg-gradient-purple.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-purple.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-purple.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-purple.btn:hover {
+  background: #6f42c1 linear-gradient(180deg, #7655b4, #5e37a6) repeat-x !important;
+  border-color: #59339d;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-purple.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-purple.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-purple.btn:active, .dark-mode .bg-gradient-purple.btn.active {
+  background: #6f42c1 linear-gradient(180deg, #7252ab, #59339d) repeat-x !important;
+  border-color: #533093;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-pink {
+  background: #e83e8c linear-gradient(180deg, #eb5b9d, #e83e8c) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-pink.btn.disabled, .dark-mode .bg-gradient-pink.btn:disabled, .dark-mode .bg-gradient-pink.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-pink.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-pink.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-pink.btn:hover {
+  background: #e83e8c linear-gradient(180deg, #e83e8c, #e41c78) repeat-x !important;
+  border-color: #d91a72;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-pink.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-pink.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-pink.btn:active, .dark-mode .bg-gradient-pink.btn.active {
+  background: #e83e8c linear-gradient(180deg, #df3c87, #d91a72) repeat-x !important;
+  border-color: #ce196c;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-red {
+  background: #e74c3c linear-gradient(180deg, #eb6759, #e74c3c) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-red.btn.disabled, .dark-mode .bg-gradient-red.btn:disabled, .dark-mode .bg-gradient-red.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-red.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-red.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-red.btn:hover {
+  background: #e74c3c linear-gradient(180deg, #e64d3e, #e12e1c) repeat-x !important;
+  border-color: #d62c1a;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-red.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-red.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-red.btn:active, .dark-mode .bg-gradient-red.btn.active {
+  background: #e74c3c linear-gradient(180deg, #dc4c3d, #d62c1a) repeat-x !important;
+  border-color: #ca2a19;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-orange {
+  background: #fd7e14 linear-gradient(180deg, #fd9137, #fd7e14) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-orange.btn.disabled, .dark-mode .bg-gradient-orange.btn:disabled, .dark-mode .bg-gradient-orange.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-orange.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-orange.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-orange.btn:hover {
+  background: #fd7e14 linear-gradient(180deg, #ec8128, #e96b02) repeat-x !important;
+  border-color: #dc6502;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-orange.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-orange.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-orange.btn:active, .dark-mode .bg-gradient-orange.btn.active {
+  background: #fd7e14 linear-gradient(180deg, #e17c28, #dc6502) repeat-x !important;
+  border-color: #cf5f02;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-yellow {
+  background: #f39c12 linear-gradient(180deg, #f5ab36, #f39c12) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-yellow.btn.disabled, .dark-mode .bg-gradient-yellow.btn:disabled, .dark-mode .bg-gradient-yellow.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-yellow.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-yellow.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-yellow.btn:hover {
+  background: #f39c12 linear-gradient(180deg, #da982f, #d4860b) repeat-x !important;
+  border-color: #c87f0a;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-yellow.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-yellow.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-yellow.btn:active, .dark-mode .bg-gradient-yellow.btn.active {
+  background: #f39c12 linear-gradient(180deg, #d0922f, #c87f0a) repeat-x !important;
+  border-color: #bc770a;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-green {
+  background: #00bc8c linear-gradient(180deg, #26c69d, #00bc8c) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-green.btn.disabled, .dark-mode .bg-gradient-green.btn:disabled, .dark-mode .bg-gradient-green.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-green.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-green.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-green.btn:hover {
+  background: #00bc8c linear-gradient(180deg, #26a685, #009670) repeat-x !important;
+  border-color: #008966;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-green.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-green.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-green.btn:active, .dark-mode .bg-gradient-green.btn.active {
+  background: #00bc8c linear-gradient(180deg, #269b7d, #008966) repeat-x !important;
+  border-color: #007c5d;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-teal {
+  background: #20c997 linear-gradient(180deg, #41d1a7, #20c997) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-teal.btn.disabled, .dark-mode .bg-gradient-teal.btn:disabled, .dark-mode .bg-gradient-teal.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-teal.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-teal.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-teal.btn:hover {
+  background: #20c997 linear-gradient(180deg, #3db592, #1ba87e) repeat-x !important;
+  border-color: #199d76;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-teal.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-teal.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-teal.btn:active, .dark-mode .bg-gradient-teal.btn.active {
+  background: #20c997 linear-gradient(180deg, #3bac8b, #199d76) repeat-x !important;
+  border-color: #17926e;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-cyan {
+  background: #3498db linear-gradient(180deg, #52a7e0, #3498db) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-cyan.btn.disabled, .dark-mode .bg-gradient-cyan.btn:disabled, .dark-mode .bg-gradient-cyan.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-cyan.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-cyan.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-cyan.btn:hover {
+  background: #3498db linear-gradient(180deg, #4497ce, #2384c6) repeat-x !important;
+  border-color: #217dbb;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-cyan.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-cyan.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-cyan.btn:active, .dark-mode .bg-gradient-cyan.btn.active {
+  background: #3498db linear-gradient(180deg, #4291c5, #217dbb) repeat-x !important;
+  border-color: #1f76b0;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-white {
+  background: #fff linear-gradient(180deg, white, #fff) repeat-x !important;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-white.btn.disabled, .dark-mode .bg-gradient-white.btn:disabled, .dark-mode .bg-gradient-white.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-white.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-white.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-white.btn:hover {
+  background: #fff linear-gradient(180deg, #efefef, #ececec) repeat-x !important;
+  border-color: #e6e6e6;
+  color: #121a24;
+}
+
+.dark-mode .bg-gradient-white.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-white.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-white.btn:active, .dark-mode .bg-gradient-white.btn.active {
+  background: #fff linear-gradient(180deg, #e9e9e9, #e6e6e6) repeat-x !important;
+  border-color: #dfdfdf;
+  color: #1f2d3d;
+}
+
+.dark-mode .bg-gradient-gray {
+  background: #6c757d linear-gradient(180deg, #828a91, #6c757d) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-gray.btn.disabled, .dark-mode .bg-gradient-gray.btn:disabled, .dark-mode .bg-gradient-gray.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-gray.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-gray.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-gray.btn:hover {
+  background: #6c757d linear-gradient(180deg, #73797f, #5a6268) repeat-x !important;
+  border-color: #545b62;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-gray.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-gray.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-gray.btn:active, .dark-mode .bg-gradient-gray.btn.active {
+  background: #6c757d linear-gradient(180deg, #6e7479, #545b62) repeat-x !important;
+  border-color: #4e555b;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-gray-dark {
+  background: #343a40 linear-gradient(180deg, #52585d, #343a40) repeat-x !important;
+  color: #fff;
+}
+
+.dark-mode .bg-gradient-gray-dark.btn.disabled, .dark-mode .bg-gradient-gray-dark.btn:disabled, .dark-mode .bg-gradient-gray-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-gray-dark.btn:not(:disabled):not(.disabled).active,
+.show > .dark-mode .bg-gradient-gray-dark.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.dark-mode .bg-gradient-gray-dark.btn:hover {
+  background: #343a40 linear-gradient(180deg, #44474b, #23272b) repeat-x !important;
+  border-color: #1d2124;
+  color: #ececec;
+}
+
+.dark-mode .bg-gradient-gray-dark.btn:not(:disabled):not(.disabled):active, .dark-mode .bg-gradient-gray-dark.btn:not(:disabled):not(.disabled).active, .dark-mode .bg-gradient-gray-dark.btn:active, .dark-mode .bg-gradient-gray-dark.btn.active {
+  background: #343a40 linear-gradient(180deg, #3f4245, #1d2124) repeat-x !important;
+  border-color: #171a1d;
+  color: #fff;
+}
+
+.dark-mode .accent-primary .btn-link,
+.dark-mode .accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-primary .nav-tabs .nav-link {
+  color: #3f6791;
+}
+
+.dark-mode .accent-primary .btn-link:hover,
+.dark-mode .accent-primary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-primary .nav-tabs .nav-link:hover {
+  color: #28415c;
+}
+
+.dark-mode .accent-primary .dropdown-item:active, .dark-mode .accent-primary .dropdown-item.active {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .accent-primary .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .accent-primary .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-primary .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-primary .custom-select:focus,
+.dark-mode .accent-primary .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-primary .custom-file-input:focus ~ .custom-file-label {
+  border-color: #85a7ca;
+}
+
+.dark-mode .accent-primary .page-item .page-link {
+  color: #3f6791;
+}
+
+.dark-mode .accent-primary .page-item.active a,
+.dark-mode .accent-primary .page-item.active .page-link {
+  background-color: #3f6791;
+  border-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .accent-primary .page-item.disabled a,
+.dark-mode .accent-primary .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-primary [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-primary [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-primary [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-primary [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-primary .page-item .page-link:hover, .dark-mode .dark-mode.accent-primary .page-item .page-link:focus {
+  color: #4774a3;
+}
+
+.dark-mode .accent-secondary .btn-link,
+.dark-mode .accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-secondary .nav-tabs .nav-link {
+  color: #6c757d;
+}
+
+.dark-mode .accent-secondary .btn-link:hover,
+.dark-mode .accent-secondary a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-secondary .nav-tabs .nav-link:hover {
+  color: #494f54;
+}
+
+.dark-mode .accent-secondary .dropdown-item:active, .dark-mode .accent-secondary .dropdown-item.active {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .accent-secondary .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .accent-secondary .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-secondary .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-secondary .custom-select:focus,
+.dark-mode .accent-secondary .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-secondary .custom-file-input:focus ~ .custom-file-label {
+  border-color: #afb5ba;
+}
+
+.dark-mode .accent-secondary .page-item .page-link {
+  color: #6c757d;
+}
+
+.dark-mode .accent-secondary .page-item.active a,
+.dark-mode .accent-secondary .page-item.active .page-link {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .accent-secondary .page-item.disabled a,
+.dark-mode .accent-secondary .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-secondary [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-secondary [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-secondary [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-secondary [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-secondary .page-item .page-link:hover, .dark-mode .dark-mode.accent-secondary .page-item .page-link:focus {
+  color: #78828a;
+}
+
+.dark-mode .accent-success .btn-link,
+.dark-mode .accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-success .nav-tabs .nav-link {
+  color: #00bc8c;
+}
+
+.dark-mode .accent-success .btn-link:hover,
+.dark-mode .accent-success a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-success .nav-tabs .nav-link:hover {
+  color: #007053;
+}
+
+.dark-mode .accent-success .dropdown-item:active, .dark-mode .accent-success .dropdown-item.active {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .accent-success .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .accent-success .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-success .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-success .custom-select:focus,
+.dark-mode .accent-success .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-success .custom-file-input:focus ~ .custom-file-label {
+  border-color: #3dffcd;
+}
+
+.dark-mode .accent-success .page-item .page-link {
+  color: #00bc8c;
+}
+
+.dark-mode .accent-success .page-item.active a,
+.dark-mode .accent-success .page-item.active .page-link {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .accent-success .page-item.disabled a,
+.dark-mode .accent-success .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-success [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-success [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-success [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-success [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-success .page-item .page-link:hover, .dark-mode .dark-mode.accent-success .page-item .page-link:focus {
+  color: #00d69f;
+}
+
+.dark-mode .accent-info .btn-link,
+.dark-mode .accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-info .nav-tabs .nav-link {
+  color: #3498db;
+}
+
+.dark-mode .accent-info .btn-link:hover,
+.dark-mode .accent-info a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-info .nav-tabs .nav-link:hover {
+  color: #1d6fa5;
+}
+
+.dark-mode .accent-info .dropdown-item:active, .dark-mode .accent-info .dropdown-item.active {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .accent-info .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .accent-info .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-info .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-info .custom-select:focus,
+.dark-mode .accent-info .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-info .custom-file-input:focus ~ .custom-file-label {
+  border-color: #a0cfee;
+}
+
+.dark-mode .accent-info .page-item .page-link {
+  color: #3498db;
+}
+
+.dark-mode .accent-info .page-item.active a,
+.dark-mode .accent-info .page-item.active .page-link {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .accent-info .page-item.disabled a,
+.dark-mode .accent-info .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-info [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-info [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-info [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-info [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-info .page-item .page-link:hover, .dark-mode .dark-mode.accent-info .page-item .page-link:focus {
+  color: #4aa3df;
+}
+
+.dark-mode .accent-warning .btn-link,
+.dark-mode .accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-warning .nav-tabs .nav-link {
+  color: #f39c12;
+}
+
+.dark-mode .accent-warning .btn-link:hover,
+.dark-mode .accent-warning a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-warning .nav-tabs .nav-link:hover {
+  color: #b06f09;
+}
+
+.dark-mode .accent-warning .dropdown-item:active, .dark-mode .accent-warning .dropdown-item.active {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-warning .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .accent-warning .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-warning .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-warning .custom-select:focus,
+.dark-mode .accent-warning .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-warning .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .accent-warning .page-item .page-link {
+  color: #f39c12;
+}
+
+.dark-mode .accent-warning .page-item.active a,
+.dark-mode .accent-warning .page-item.active .page-link {
+  background-color: #f39c12;
+  border-color: #f39c12;
+  color: #fff;
+}
+
+.dark-mode .accent-warning .page-item.disabled a,
+.dark-mode .accent-warning .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-warning [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-warning [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-warning [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-warning [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-warning .page-item .page-link:hover, .dark-mode .dark-mode.accent-warning .page-item .page-link:focus {
+  color: #f4a62a;
+}
+
+.dark-mode .accent-danger .btn-link,
+.dark-mode .accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-danger .nav-tabs .nav-link {
+  color: #e74c3c;
+}
+
+.dark-mode .accent-danger .btn-link:hover,
+.dark-mode .accent-danger a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-danger .nav-tabs .nav-link:hover {
+  color: #bf2718;
+}
+
+.dark-mode .accent-danger .dropdown-item:active, .dark-mode .accent-danger .dropdown-item.active {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .accent-danger .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .accent-danger .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-danger .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-danger .custom-select:focus,
+.dark-mode .accent-danger .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-danger .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .accent-danger .page-item .page-link {
+  color: #e74c3c;
+}
+
+.dark-mode .accent-danger .page-item.active a,
+.dark-mode .accent-danger .page-item.active .page-link {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .accent-danger .page-item.disabled a,
+.dark-mode .accent-danger .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-danger [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-danger [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-danger [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-danger [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-danger .page-item .page-link:hover, .dark-mode .dark-mode.accent-danger .page-item .page-link:focus {
+  color: #ea6153;
+}
+
+.dark-mode .accent-light .btn-link,
+.dark-mode .accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-light .nav-tabs .nav-link {
+  color: #f8f9fa;
+}
+
+.dark-mode .accent-light .btn-link:hover,
+.dark-mode .accent-light a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-light .nav-tabs .nav-link:hover {
+  color: #cbd3da;
+}
+
+.dark-mode .accent-light .dropdown-item:active, .dark-mode .accent-light .dropdown-item.active {
+  background-color: #f8f9fa;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-light .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f8f9fa;
+  border-color: #bdc6d0;
+}
+
+.dark-mode .accent-light .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-light .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-light .custom-select:focus,
+.dark-mode .accent-light .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-light .custom-file-input:focus ~ .custom-file-label {
+  border-color: white;
+}
+
+.dark-mode .accent-light .page-item .page-link {
+  color: #f8f9fa;
+}
+
+.dark-mode .accent-light .page-item.active a,
+.dark-mode .accent-light .page-item.active .page-link {
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+  color: #fff;
+}
+
+.dark-mode .accent-light .page-item.disabled a,
+.dark-mode .accent-light .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-light [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-light [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-light [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-light [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-light .page-item .page-link:hover, .dark-mode .dark-mode.accent-light .page-item .page-link:focus {
+  color: white;
+}
+
+.dark-mode .accent-dark .btn-link,
+.dark-mode .accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-dark .nav-tabs .nav-link {
+  color: #343a40;
+}
+
+.dark-mode .accent-dark .btn-link:hover,
+.dark-mode .accent-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-dark .nav-tabs .nav-link:hover {
+  color: #121416;
+}
+
+.dark-mode .accent-dark .dropdown-item:active, .dark-mode .accent-dark .dropdown-item.active {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .accent-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .accent-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-dark .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-dark .custom-select:focus,
+.dark-mode .accent-dark .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-dark .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6d7a86;
+}
+
+.dark-mode .accent-dark .page-item .page-link {
+  color: #343a40;
+}
+
+.dark-mode .accent-dark .page-item.active a,
+.dark-mode .accent-dark .page-item.active .page-link {
+  background-color: #343a40;
+  border-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .accent-dark .page-item.disabled a,
+.dark-mode .accent-dark .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-dark [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-dark [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-dark [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-dark [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-dark .page-item .page-link:hover, .dark-mode .dark-mode.accent-dark .page-item .page-link:focus {
+  color: #3f474e;
+}
+
+.dark-mode [class*="accent-"] a.btn-primary {
+  color: #fff;
+}
+
+.dark-mode [class*="accent-"] a.btn-secondary {
+  color: #fff;
+}
+
+.dark-mode [class*="accent-"] a.btn-success {
+  color: #fff;
+}
+
+.dark-mode [class*="accent-"] a.btn-info {
+  color: #fff;
+}
+
+.dark-mode [class*="accent-"] a.btn-warning {
+  color: #1f2d3d;
+}
+
+.dark-mode [class*="accent-"] a.btn-danger {
+  color: #fff;
+}
+
+.dark-mode [class*="accent-"] a.btn-light {
+  color: #1f2d3d;
+}
+
+.dark-mode [class*="accent-"] a.btn-dark {
+  color: #fff;
+}
+
+.dark-mode .accent-lightblue .btn-link,
+.dark-mode .accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-lightblue .nav-tabs .nav-link {
+  color: #86bad8;
+}
+
+.dark-mode .accent-lightblue .btn-link:hover,
+.dark-mode .accent-lightblue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-lightblue .nav-tabs .nav-link:hover {
+  color: #4c99c6;
+}
+
+.dark-mode .accent-lightblue .dropdown-item:active, .dark-mode .accent-lightblue .dropdown-item.active {
+  background-color: #86bad8;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-lightblue .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #86bad8;
+  border-color: #3c8dbc;
+}
+
+.dark-mode .accent-lightblue .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-lightblue .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-lightblue .custom-select:focus,
+.dark-mode .accent-lightblue .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-lightblue .custom-file-input:focus ~ .custom-file-label {
+  border-color: #e6f1f7;
+}
+
+.dark-mode .accent-lightblue .page-item .page-link {
+  color: #86bad8;
+}
+
+.dark-mode .accent-lightblue .page-item.active a,
+.dark-mode .accent-lightblue .page-item.active .page-link {
+  background-color: #86bad8;
+  border-color: #86bad8;
+  color: #fff;
+}
+
+.dark-mode .accent-lightblue .page-item.disabled a,
+.dark-mode .accent-lightblue .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-lightblue [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-lightblue [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-lightblue [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-lightblue [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-lightblue .page-item .page-link:hover, .dark-mode .dark-mode.accent-lightblue .page-item .page-link:focus {
+  color: #99c5de;
+}
+
+.dark-mode .accent-navy .btn-link,
+.dark-mode .accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-navy .nav-tabs .nav-link {
+  color: #002c59;
+}
+
+.dark-mode .accent-navy .btn-link:hover,
+.dark-mode .accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-navy .nav-tabs .nav-link:hover {
+  color: #00060c;
+}
+
+.dark-mode .accent-navy .dropdown-item:active, .dark-mode .accent-navy .dropdown-item.active {
+  background-color: #002c59;
+  color: #fff;
+}
+
+.dark-mode .accent-navy .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #002c59;
+  border-color: black;
+}
+
+.dark-mode .accent-navy .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-navy .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-navy .custom-select:focus,
+.dark-mode .accent-navy .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-navy .custom-file-input:focus ~ .custom-file-label {
+  border-color: #006ad8;
+}
+
+.dark-mode .accent-navy .page-item .page-link {
+  color: #002c59;
+}
+
+.dark-mode .accent-navy .page-item.active a,
+.dark-mode .accent-navy .page-item.active .page-link {
+  background-color: #002c59;
+  border-color: #002c59;
+  color: #fff;
+}
+
+.dark-mode .accent-navy .page-item.disabled a,
+.dark-mode .accent-navy .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-navy [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-navy [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-navy [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-navy [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-navy .page-item .page-link:hover, .dark-mode .dark-mode.accent-navy .page-item .page-link:focus {
+  color: #003872;
+}
+
+.dark-mode .accent-olive .btn-link,
+.dark-mode .accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-olive .nav-tabs .nav-link {
+  color: #74c8a3;
+}
+
+.dark-mode .accent-olive .btn-link:hover,
+.dark-mode .accent-olive a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-olive .nav-tabs .nav-link:hover {
+  color: #44ab7d;
+}
+
+.dark-mode .accent-olive .dropdown-item:active, .dark-mode .accent-olive .dropdown-item.active {
+  background-color: #74c8a3;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-olive .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #74c8a3;
+  border-color: #3d9970;
+}
+
+.dark-mode .accent-olive .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-olive .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-olive .custom-select:focus,
+.dark-mode .accent-olive .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-olive .custom-file-input:focus ~ .custom-file-label {
+  border-color: #cfecdf;
+}
+
+.dark-mode .accent-olive .page-item .page-link {
+  color: #74c8a3;
+}
+
+.dark-mode .accent-olive .page-item.active a,
+.dark-mode .accent-olive .page-item.active .page-link {
+  background-color: #74c8a3;
+  border-color: #74c8a3;
+  color: #fff;
+}
+
+.dark-mode .accent-olive .page-item.disabled a,
+.dark-mode .accent-olive .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-olive [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-olive [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-olive [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-olive [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-olive .page-item .page-link:hover, .dark-mode .dark-mode.accent-olive .page-item .page-link:focus {
+  color: #87cfaf;
+}
+
+.dark-mode .accent-lime .btn-link,
+.dark-mode .accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-lime .nav-tabs .nav-link {
+  color: #67ffa9;
+}
+
+.dark-mode .accent-lime .btn-link:hover,
+.dark-mode .accent-lime a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-lime .nav-tabs .nav-link:hover {
+  color: #1bff7e;
+}
+
+.dark-mode .accent-lime .dropdown-item:active, .dark-mode .accent-lime .dropdown-item.active {
+  background-color: #67ffa9;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-lime .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #67ffa9;
+  border-color: #01ff70;
+}
+
+.dark-mode .accent-lime .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-lime .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-lime .custom-select:focus,
+.dark-mode .accent-lime .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-lime .custom-file-input:focus ~ .custom-file-label {
+  border-color: #e7fff1;
+}
+
+.dark-mode .accent-lime .page-item .page-link {
+  color: #67ffa9;
+}
+
+.dark-mode .accent-lime .page-item.active a,
+.dark-mode .accent-lime .page-item.active .page-link {
+  background-color: #67ffa9;
+  border-color: #67ffa9;
+  color: #fff;
+}
+
+.dark-mode .accent-lime .page-item.disabled a,
+.dark-mode .accent-lime .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-lime [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-lime [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-lime [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-lime [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-lime .page-item .page-link:hover, .dark-mode .dark-mode.accent-lime .page-item .page-link:focus {
+  color: #81ffb8;
+}
+
+.dark-mode .accent-fuchsia .btn-link,
+.dark-mode .accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-fuchsia .nav-tabs .nav-link {
+  color: #f672d8;
+}
+
+.dark-mode .accent-fuchsia .btn-link:hover,
+.dark-mode .accent-fuchsia a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-fuchsia .nav-tabs .nav-link:hover {
+  color: #f22ac5;
+}
+
+.dark-mode .accent-fuchsia .dropdown-item:active, .dark-mode .accent-fuchsia .dropdown-item.active {
+  background-color: #f672d8;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-fuchsia .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f672d8;
+  border-color: #f012be;
+}
+
+.dark-mode .accent-fuchsia .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-fuchsia .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-fuchsia .custom-select:focus,
+.dark-mode .accent-fuchsia .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-fuchsia .custom-file-input:focus ~ .custom-file-label {
+  border-color: #feeaf9;
+}
+
+.dark-mode .accent-fuchsia .page-item .page-link {
+  color: #f672d8;
+}
+
+.dark-mode .accent-fuchsia .page-item.active a,
+.dark-mode .accent-fuchsia .page-item.active .page-link {
+  background-color: #f672d8;
+  border-color: #f672d8;
+  color: #fff;
+}
+
+.dark-mode .accent-fuchsia .page-item.disabled a,
+.dark-mode .accent-fuchsia .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-fuchsia [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-fuchsia [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-fuchsia [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-fuchsia [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-fuchsia .page-item .page-link:hover, .dark-mode .dark-mode.accent-fuchsia .page-item .page-link:focus {
+  color: #f88adf;
+}
+
+.dark-mode .accent-maroon .btn-link,
+.dark-mode .accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-maroon .nav-tabs .nav-link {
+  color: #ed6c9b;
+}
+
+.dark-mode .accent-maroon .btn-link:hover,
+.dark-mode .accent-maroon a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-maroon .nav-tabs .nav-link:hover {
+  color: #e4286d;
+}
+
+.dark-mode .accent-maroon .dropdown-item:active, .dark-mode .accent-maroon .dropdown-item.active {
+  background-color: #ed6c9b;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-maroon .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #ed6c9b;
+  border-color: #d81b60;
+}
+
+.dark-mode .accent-maroon .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-maroon .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-maroon .custom-select:focus,
+.dark-mode .accent-maroon .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-maroon .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fbdee8;
+}
+
+.dark-mode .accent-maroon .page-item .page-link {
+  color: #ed6c9b;
+}
+
+.dark-mode .accent-maroon .page-item.active a,
+.dark-mode .accent-maroon .page-item.active .page-link {
+  background-color: #ed6c9b;
+  border-color: #ed6c9b;
+  color: #fff;
+}
+
+.dark-mode .accent-maroon .page-item.disabled a,
+.dark-mode .accent-maroon .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-maroon [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-maroon [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-maroon [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-maroon [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-maroon .page-item .page-link:hover, .dark-mode .dark-mode.accent-maroon .page-item .page-link:focus {
+  color: #f083ab;
+}
+
+.dark-mode .accent-blue .btn-link,
+.dark-mode .accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-blue .nav-tabs .nav-link {
+  color: #3f6791;
+}
+
+.dark-mode .accent-blue .btn-link:hover,
+.dark-mode .accent-blue a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-blue .nav-tabs .nav-link:hover {
+  color: #28415c;
+}
+
+.dark-mode .accent-blue .dropdown-item:active, .dark-mode .accent-blue .dropdown-item.active {
+  background-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .accent-blue .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3f6791;
+  border-color: #20344a;
+}
+
+.dark-mode .accent-blue .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-blue .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-blue .custom-select:focus,
+.dark-mode .accent-blue .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-blue .custom-file-input:focus ~ .custom-file-label {
+  border-color: #85a7ca;
+}
+
+.dark-mode .accent-blue .page-item .page-link {
+  color: #3f6791;
+}
+
+.dark-mode .accent-blue .page-item.active a,
+.dark-mode .accent-blue .page-item.active .page-link {
+  background-color: #3f6791;
+  border-color: #3f6791;
+  color: #fff;
+}
+
+.dark-mode .accent-blue .page-item.disabled a,
+.dark-mode .accent-blue .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-blue [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-blue [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-blue [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-blue [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-blue .page-item .page-link:hover, .dark-mode .dark-mode.accent-blue .page-item .page-link:focus {
+  color: #4774a3;
+}
+
+.dark-mode .accent-indigo .btn-link,
+.dark-mode .accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-indigo .nav-tabs .nav-link {
+  color: #6610f2;
+}
+
+.dark-mode .accent-indigo .btn-link:hover,
+.dark-mode .accent-indigo a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-indigo .nav-tabs .nav-link:hover {
+  color: #4709ac;
+}
+
+.dark-mode .accent-indigo .dropdown-item:active, .dark-mode .accent-indigo .dropdown-item.active {
+  background-color: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .accent-indigo .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6610f2;
+  border-color: #3d0894;
+}
+
+.dark-mode .accent-indigo .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-indigo .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-indigo .custom-select:focus,
+.dark-mode .accent-indigo .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-indigo .custom-file-input:focus ~ .custom-file-label {
+  border-color: #b389f9;
+}
+
+.dark-mode .accent-indigo .page-item .page-link {
+  color: #6610f2;
+}
+
+.dark-mode .accent-indigo .page-item.active a,
+.dark-mode .accent-indigo .page-item.active .page-link {
+  background-color: #6610f2;
+  border-color: #6610f2;
+  color: #fff;
+}
+
+.dark-mode .accent-indigo .page-item.disabled a,
+.dark-mode .accent-indigo .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-indigo [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-indigo [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-indigo [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-indigo [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-indigo .page-item .page-link:hover, .dark-mode .dark-mode.accent-indigo .page-item .page-link:focus {
+  color: #7528f3;
+}
+
+.dark-mode .accent-purple .btn-link,
+.dark-mode .accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-purple .nav-tabs .nav-link {
+  color: #6f42c1;
+}
+
+.dark-mode .accent-purple .btn-link:hover,
+.dark-mode .accent-purple a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-purple .nav-tabs .nav-link:hover {
+  color: #4e2d89;
+}
+
+.dark-mode .accent-purple .dropdown-item:active, .dark-mode .accent-purple .dropdown-item.active {
+  background-color: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .accent-purple .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6f42c1;
+  border-color: #432776;
+}
+
+.dark-mode .accent-purple .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-purple .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-purple .custom-select:focus,
+.dark-mode .accent-purple .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-purple .custom-file-input:focus ~ .custom-file-label {
+  border-color: #b8a2e0;
+}
+
+.dark-mode .accent-purple .page-item .page-link {
+  color: #6f42c1;
+}
+
+.dark-mode .accent-purple .page-item.active a,
+.dark-mode .accent-purple .page-item.active .page-link {
+  background-color: #6f42c1;
+  border-color: #6f42c1;
+  color: #fff;
+}
+
+.dark-mode .accent-purple .page-item.disabled a,
+.dark-mode .accent-purple .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-purple [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-purple [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-purple [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-purple [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-purple .page-item .page-link:hover, .dark-mode .dark-mode.accent-purple .page-item .page-link:focus {
+  color: #7e55c7;
+}
+
+.dark-mode .accent-pink .btn-link,
+.dark-mode .accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-pink .nav-tabs .nav-link {
+  color: #e83e8c;
+}
+
+.dark-mode .accent-pink .btn-link:hover,
+.dark-mode .accent-pink a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-pink .nav-tabs .nav-link:hover {
+  color: #c21766;
+}
+
+.dark-mode .accent-pink .dropdown-item:active, .dark-mode .accent-pink .dropdown-item.active {
+  background-color: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .accent-pink .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e83e8c;
+  border-color: #ac145a;
+}
+
+.dark-mode .accent-pink .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-pink .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-pink .custom-select:focus,
+.dark-mode .accent-pink .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-pink .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f6b0d0;
+}
+
+.dark-mode .accent-pink .page-item .page-link {
+  color: #e83e8c;
+}
+
+.dark-mode .accent-pink .page-item.active a,
+.dark-mode .accent-pink .page-item.active .page-link {
+  background-color: #e83e8c;
+  border-color: #e83e8c;
+  color: #fff;
+}
+
+.dark-mode .accent-pink .page-item.disabled a,
+.dark-mode .accent-pink .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-pink [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-pink [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-pink [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-pink [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-pink .page-item .page-link:hover, .dark-mode .dark-mode.accent-pink .page-item .page-link:focus {
+  color: #eb559a;
+}
+
+.dark-mode .accent-red .btn-link,
+.dark-mode .accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-red .nav-tabs .nav-link {
+  color: #e74c3c;
+}
+
+.dark-mode .accent-red .btn-link:hover,
+.dark-mode .accent-red a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-red .nav-tabs .nav-link:hover {
+  color: #bf2718;
+}
+
+.dark-mode .accent-red .dropdown-item:active, .dark-mode .accent-red .dropdown-item.active {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .accent-red .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #e74c3c;
+  border-color: #a82315;
+}
+
+.dark-mode .accent-red .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-red .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-red .custom-select:focus,
+.dark-mode .accent-red .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-red .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f5b4ae;
+}
+
+.dark-mode .accent-red .page-item .page-link {
+  color: #e74c3c;
+}
+
+.dark-mode .accent-red .page-item.active a,
+.dark-mode .accent-red .page-item.active .page-link {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  color: #fff;
+}
+
+.dark-mode .accent-red .page-item.disabled a,
+.dark-mode .accent-red .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-red [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-red [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-red [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-red [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-red .page-item .page-link:hover, .dark-mode .dark-mode.accent-red .page-item .page-link:focus {
+  color: #ea6153;
+}
+
+.dark-mode .accent-orange .btn-link,
+.dark-mode .accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-orange .nav-tabs .nav-link {
+  color: #fd7e14;
+}
+
+.dark-mode .accent-orange .btn-link:hover,
+.dark-mode .accent-orange a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-orange .nav-tabs .nav-link:hover {
+  color: #c35a02;
+}
+
+.dark-mode .accent-orange .dropdown-item:active, .dark-mode .accent-orange .dropdown-item.active {
+  background-color: #fd7e14;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-orange .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #fd7e14;
+  border-color: #aa4e01;
+}
+
+.dark-mode .accent-orange .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-orange .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-orange .custom-select:focus,
+.dark-mode .accent-orange .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-orange .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fec392;
+}
+
+.dark-mode .accent-orange .page-item .page-link {
+  color: #fd7e14;
+}
+
+.dark-mode .accent-orange .page-item.active a,
+.dark-mode .accent-orange .page-item.active .page-link {
+  background-color: #fd7e14;
+  border-color: #fd7e14;
+  color: #fff;
+}
+
+.dark-mode .accent-orange .page-item.disabled a,
+.dark-mode .accent-orange .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-orange [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-orange [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-orange [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-orange [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-orange .page-item .page-link:hover, .dark-mode .dark-mode.accent-orange .page-item .page-link:focus {
+  color: #fd8c2d;
+}
+
+.dark-mode .accent-yellow .btn-link,
+.dark-mode .accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-yellow .nav-tabs .nav-link {
+  color: #f39c12;
+}
+
+.dark-mode .accent-yellow .btn-link:hover,
+.dark-mode .accent-yellow a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-yellow .nav-tabs .nav-link:hover {
+  color: #b06f09;
+}
+
+.dark-mode .accent-yellow .dropdown-item:active, .dark-mode .accent-yellow .dropdown-item.active {
+  background-color: #f39c12;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-yellow .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #f39c12;
+  border-color: #976008;
+}
+
+.dark-mode .accent-yellow .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-yellow .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-yellow .custom-select:focus,
+.dark-mode .accent-yellow .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-yellow .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f9cf8b;
+}
+
+.dark-mode .accent-yellow .page-item .page-link {
+  color: #f39c12;
+}
+
+.dark-mode .accent-yellow .page-item.active a,
+.dark-mode .accent-yellow .page-item.active .page-link {
+  background-color: #f39c12;
+  border-color: #f39c12;
+  color: #fff;
+}
+
+.dark-mode .accent-yellow .page-item.disabled a,
+.dark-mode .accent-yellow .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-yellow [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-yellow [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-yellow [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-yellow [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-yellow .page-item .page-link:hover, .dark-mode .dark-mode.accent-yellow .page-item .page-link:focus {
+  color: #f4a62a;
+}
+
+.dark-mode .accent-green .btn-link,
+.dark-mode .accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-green .nav-tabs .nav-link {
+  color: #00bc8c;
+}
+
+.dark-mode .accent-green .btn-link:hover,
+.dark-mode .accent-green a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-green .nav-tabs .nav-link:hover {
+  color: #007053;
+}
+
+.dark-mode .accent-green .dropdown-item:active, .dark-mode .accent-green .dropdown-item.active {
+  background-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .accent-green .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #00bc8c;
+  border-color: #005640;
+}
+
+.dark-mode .accent-green .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-green .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-green .custom-select:focus,
+.dark-mode .accent-green .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-green .custom-file-input:focus ~ .custom-file-label {
+  border-color: #3dffcd;
+}
+
+.dark-mode .accent-green .page-item .page-link {
+  color: #00bc8c;
+}
+
+.dark-mode .accent-green .page-item.active a,
+.dark-mode .accent-green .page-item.active .page-link {
+  background-color: #00bc8c;
+  border-color: #00bc8c;
+  color: #fff;
+}
+
+.dark-mode .accent-green .page-item.disabled a,
+.dark-mode .accent-green .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-green [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-green [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-green [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-green [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-green .page-item .page-link:hover, .dark-mode .dark-mode.accent-green .page-item .page-link:focus {
+  color: #00d69f;
+}
+
+.dark-mode .accent-teal .btn-link,
+.dark-mode .accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-teal .nav-tabs .nav-link {
+  color: #20c997;
+}
+
+.dark-mode .accent-teal .btn-link:hover,
+.dark-mode .accent-teal a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-teal .nav-tabs .nav-link:hover {
+  color: #158765;
+}
+
+.dark-mode .accent-teal .dropdown-item:active, .dark-mode .accent-teal .dropdown-item.active {
+  background-color: #20c997;
+  color: #fff;
+}
+
+.dark-mode .accent-teal .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #20c997;
+  border-color: #127155;
+}
+
+.dark-mode .accent-teal .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-teal .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-teal .custom-select:focus,
+.dark-mode .accent-teal .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-teal .custom-file-input:focus ~ .custom-file-label {
+  border-color: #7eeaca;
+}
+
+.dark-mode .accent-teal .page-item .page-link {
+  color: #20c997;
+}
+
+.dark-mode .accent-teal .page-item.active a,
+.dark-mode .accent-teal .page-item.active .page-link {
+  background-color: #20c997;
+  border-color: #20c997;
+  color: #fff;
+}
+
+.dark-mode .accent-teal .page-item.disabled a,
+.dark-mode .accent-teal .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-teal [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-teal [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-teal [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-teal [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-teal .page-item .page-link:hover, .dark-mode .dark-mode.accent-teal .page-item .page-link:focus {
+  color: #26dca6;
+}
+
+.dark-mode .accent-cyan .btn-link,
+.dark-mode .accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-cyan .nav-tabs .nav-link {
+  color: #3498db;
+}
+
+.dark-mode .accent-cyan .btn-link:hover,
+.dark-mode .accent-cyan a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-cyan .nav-tabs .nav-link:hover {
+  color: #1d6fa5;
+}
+
+.dark-mode .accent-cyan .dropdown-item:active, .dark-mode .accent-cyan .dropdown-item.active {
+  background-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .accent-cyan .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #3498db;
+  border-color: #196090;
+}
+
+.dark-mode .accent-cyan .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-cyan .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-cyan .custom-select:focus,
+.dark-mode .accent-cyan .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-cyan .custom-file-input:focus ~ .custom-file-label {
+  border-color: #a0cfee;
+}
+
+.dark-mode .accent-cyan .page-item .page-link {
+  color: #3498db;
+}
+
+.dark-mode .accent-cyan .page-item.active a,
+.dark-mode .accent-cyan .page-item.active .page-link {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #fff;
+}
+
+.dark-mode .accent-cyan .page-item.disabled a,
+.dark-mode .accent-cyan .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-cyan [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-cyan [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-cyan [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-cyan [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-cyan .page-item .page-link:hover, .dark-mode .dark-mode.accent-cyan .page-item .page-link:focus {
+  color: #4aa3df;
+}
+
+.dark-mode .accent-white .btn-link,
+.dark-mode .accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-white .nav-tabs .nav-link {
+  color: #fff;
+}
+
+.dark-mode .accent-white .btn-link:hover,
+.dark-mode .accent-white a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-white .nav-tabs .nav-link:hover {
+  color: #d9d9d9;
+}
+
+.dark-mode .accent-white .dropdown-item:active, .dark-mode .accent-white .dropdown-item.active {
+  background-color: #fff;
+  color: #1f2d3d;
+}
+
+.dark-mode .accent-white .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #fff;
+  border-color: #cccccc;
+}
+
+.dark-mode .accent-white .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231f2d3d' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-white .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-white .custom-select:focus,
+.dark-mode .accent-white .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-white .custom-file-input:focus ~ .custom-file-label {
+  border-color: white;
+}
+
+.dark-mode .accent-white .page-item .page-link {
+  color: #fff;
+}
+
+.dark-mode .accent-white .page-item.active a,
+.dark-mode .accent-white .page-item.active .page-link {
+  background-color: #fff;
+  border-color: #fff;
+  color: #fff;
+}
+
+.dark-mode .accent-white .page-item.disabled a,
+.dark-mode .accent-white .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-white [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-white [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-white [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-white [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-white .page-item .page-link:hover, .dark-mode .dark-mode.accent-white .page-item .page-link:focus {
+  color: white;
+}
+
+.dark-mode .accent-gray .btn-link,
+.dark-mode .accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-gray .nav-tabs .nav-link {
+  color: #6c757d;
+}
+
+.dark-mode .accent-gray .btn-link:hover,
+.dark-mode .accent-gray a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-gray .nav-tabs .nav-link:hover {
+  color: #494f54;
+}
+
+.dark-mode .accent-gray .dropdown-item:active, .dark-mode .accent-gray .dropdown-item.active {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .accent-gray .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #6c757d;
+  border-color: #3d4246;
+}
+
+.dark-mode .accent-gray .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-gray .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-gray .custom-select:focus,
+.dark-mode .accent-gray .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-gray .custom-file-input:focus ~ .custom-file-label {
+  border-color: #afb5ba;
+}
+
+.dark-mode .accent-gray .page-item .page-link {
+  color: #6c757d;
+}
+
+.dark-mode .accent-gray .page-item.active a,
+.dark-mode .accent-gray .page-item.active .page-link {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.dark-mode .accent-gray .page-item.disabled a,
+.dark-mode .accent-gray .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-gray [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-gray [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-gray [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-gray [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-gray .page-item .page-link:hover, .dark-mode .dark-mode.accent-gray .page-item .page-link:focus {
+  color: #78828a;
+}
+
+.dark-mode .accent-gray-dark .btn-link,
+.dark-mode .accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn),
+.dark-mode .accent-gray-dark .nav-tabs .nav-link {
+  color: #343a40;
+}
+
+.dark-mode .accent-gray-dark .btn-link:hover,
+.dark-mode .accent-gray-dark a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover,
+.dark-mode .accent-gray-dark .nav-tabs .nav-link:hover {
+  color: #121416;
+}
+
+.dark-mode .accent-gray-dark .dropdown-item:active, .dark-mode .accent-gray-dark .dropdown-item.active {
+  background-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .accent-gray-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #343a40;
+  border-color: #060708;
+}
+
+.dark-mode .accent-gray-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.dark-mode .accent-gray-dark .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.dark-mode .accent-gray-dark .custom-select:focus,
+.dark-mode .accent-gray-dark .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.dark-mode .accent-gray-dark .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6d7a86;
+}
+
+.dark-mode .accent-gray-dark .page-item .page-link {
+  color: #343a40;
+}
+
+.dark-mode .accent-gray-dark .page-item.active a,
+.dark-mode .accent-gray-dark .page-item.active .page-link {
+  background-color: #343a40;
+  border-color: #343a40;
+  color: #fff;
+}
+
+.dark-mode .accent-gray-dark .page-item.disabled a,
+.dark-mode .accent-gray-dark .page-item.disabled .page-link {
+  background-color: #fff;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.dark-mode .accent-gray-dark [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #c2c7d0;
+}
+
+.dark-mode .accent-gray-dark [class*="sidebar-dark-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #fff;
+}
+
+.dark-mode .accent-gray-dark [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link) {
+  color: #343a40;
+}
+
+.dark-mode .accent-gray-dark [class*="sidebar-light-"] .sidebar a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):hover {
+  color: #212529;
+}
+
+.dark-mode .dark-mode.accent-gray-dark .page-item .page-link:hover, .dark-mode .dark-mode.accent-gray-dark .page-item .page-link:focus {
+  color: #3f474e;
 }
 /*# sourceMappingURL=adminlte.css.map */

--- a/static/jscn/adminlte.js
+++ b/static/jscn/adminlte.js
@@ -1,6 +1,6 @@
 /*!
- * AdminLTE v3.1.0-rc (https://adminlte.io)
- * Copyright 2014-2020 Colorlib <https://colorlib.com>
+ * AdminLTE v3.1.0 (https://adminlte.io)
+ * Copyright 2014-2021 Colorlib <https://colorlib.com>
  * Licensed under MIT (https://github.com/ColorlibHQ/AdminLTE/blob/master/LICENSE)
  */
 (function (global, factory) {
@@ -24,17 +24,17 @@
    * ====================================================
    */
 
-  var NAME = 'CardRefresh';
-  var DATA_KEY = 'lte.cardrefresh';
-  var EVENT_KEY = "." + DATA_KEY;
-  var JQUERY_NO_CONFLICT = $__default['default'].fn[NAME];
-  var EVENT_LOADED = "loaded" + EVENT_KEY;
-  var EVENT_OVERLAY_ADDED = "overlay.added" + EVENT_KEY;
-  var EVENT_OVERLAY_REMOVED = "overlay.removed" + EVENT_KEY;
-  var CLASS_NAME_CARD = 'card';
-  var SELECTOR_CARD = "." + CLASS_NAME_CARD;
+  var NAME$e = 'CardRefresh';
+  var DATA_KEY$e = 'lte.cardrefresh';
+  var EVENT_KEY$7 = "." + DATA_KEY$e;
+  var JQUERY_NO_CONFLICT$e = $__default['default'].fn[NAME$e];
+  var EVENT_LOADED = "loaded" + EVENT_KEY$7;
+  var EVENT_OVERLAY_ADDED = "overlay.added" + EVENT_KEY$7;
+  var EVENT_OVERLAY_REMOVED = "overlay.removed" + EVENT_KEY$7;
+  var CLASS_NAME_CARD$1 = 'card';
+  var SELECTOR_CARD$1 = "." + CLASS_NAME_CARD$1;
   var SELECTOR_DATA_REFRESH = '[data-card-widget="card-refresh"]';
-  var Default = {
+  var Default$c = {
     source: '',
     sourceSelector: '',
     params: {},
@@ -53,11 +53,11 @@
   var CardRefresh = /*#__PURE__*/function () {
     function CardRefresh(element, settings) {
       this._element = element;
-      this._parent = element.parents(SELECTOR_CARD).first();
-      this._settings = $__default['default'].extend({}, Default, settings);
+      this._parent = element.parents(SELECTOR_CARD$1).first();
+      this._settings = $__default['default'].extend({}, Default$c, settings);
       this._overlay = $__default['default'](this._settings.overlayTemplate);
 
-      if (element.hasClass(CLASS_NAME_CARD)) {
+      if (element.hasClass(CLASS_NAME_CARD$1)) {
         this._parent = element;
       }
 
@@ -118,16 +118,16 @@
     ;
 
     CardRefresh._jQueryInterface = function _jQueryInterface(config) {
-      var data = $__default['default'](this).data(DATA_KEY);
+      var data = $__default['default'](this).data(DATA_KEY$e);
 
-      var _options = $__default['default'].extend({}, Default, $__default['default'](this).data());
+      var _options = $__default['default'].extend({}, Default$c, $__default['default'](this).data());
 
       if (!data) {
         data = new CardRefresh($__default['default'](this), _options);
-        $__default['default'](this).data(DATA_KEY, typeof config === 'string' ? data : config);
+        $__default['default'](this).data(DATA_KEY$e, typeof config === 'string' ? data : config);
       }
 
-      if (typeof config === 'string' && config.match(/load/)) {
+      if (typeof config === 'string' && /load/.test(config)) {
         data[config]();
       } else {
         data._init($__default['default'](this));
@@ -159,11 +159,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME] = CardRefresh._jQueryInterface;
-  $__default['default'].fn[NAME].Constructor = CardRefresh;
+  $__default['default'].fn[NAME$e] = CardRefresh._jQueryInterface;
+  $__default['default'].fn[NAME$e].Constructor = CardRefresh;
 
-  $__default['default'].fn[NAME].noConflict = function () {
-    $__default['default'].fn[NAME] = JQUERY_NO_CONFLICT;
+  $__default['default'].fn[NAME$e].noConflict = function () {
+    $__default['default'].fn[NAME$e] = JQUERY_NO_CONFLICT$e;
     return CardRefresh._jQueryInterface;
   };
 
@@ -178,17 +178,17 @@
    * ====================================================
    */
 
-  var NAME$1 = 'CardWidget';
-  var DATA_KEY$1 = 'lte.cardwidget';
-  var EVENT_KEY$1 = "." + DATA_KEY$1;
-  var JQUERY_NO_CONFLICT$1 = $__default['default'].fn[NAME$1];
-  var EVENT_EXPANDED = "expanded" + EVENT_KEY$1;
-  var EVENT_COLLAPSED = "collapsed" + EVENT_KEY$1;
-  var EVENT_MAXIMIZED = "maximized" + EVENT_KEY$1;
-  var EVENT_MINIMIZED = "minimized" + EVENT_KEY$1;
-  var EVENT_REMOVED = "removed" + EVENT_KEY$1;
-  var CLASS_NAME_CARD$1 = 'card';
-  var CLASS_NAME_COLLAPSED = 'collapsed-card';
+  var NAME$d = 'CardWidget';
+  var DATA_KEY$d = 'lte.cardwidget';
+  var EVENT_KEY$6 = "." + DATA_KEY$d;
+  var JQUERY_NO_CONFLICT$d = $__default['default'].fn[NAME$d];
+  var EVENT_EXPANDED$3 = "expanded" + EVENT_KEY$6;
+  var EVENT_COLLAPSED$4 = "collapsed" + EVENT_KEY$6;
+  var EVENT_MAXIMIZED = "maximized" + EVENT_KEY$6;
+  var EVENT_MINIMIZED = "minimized" + EVENT_KEY$6;
+  var EVENT_REMOVED$1 = "removed" + EVENT_KEY$6;
+  var CLASS_NAME_CARD = 'card';
+  var CLASS_NAME_COLLAPSED$1 = 'collapsed-card';
   var CLASS_NAME_COLLAPSING = 'collapsing-card';
   var CLASS_NAME_EXPANDING = 'expanding-card';
   var CLASS_NAME_WAS_COLLAPSED = 'was-collapsed';
@@ -196,11 +196,11 @@
   var SELECTOR_DATA_REMOVE = '[data-card-widget="remove"]';
   var SELECTOR_DATA_COLLAPSE = '[data-card-widget="collapse"]';
   var SELECTOR_DATA_MAXIMIZE = '[data-card-widget="maximize"]';
-  var SELECTOR_CARD$1 = "." + CLASS_NAME_CARD$1;
+  var SELECTOR_CARD = "." + CLASS_NAME_CARD;
   var SELECTOR_CARD_HEADER = '.card-header';
   var SELECTOR_CARD_BODY = '.card-body';
   var SELECTOR_CARD_FOOTER = '.card-footer';
-  var Default$1 = {
+  var Default$b = {
     animationSpeed: 'normal',
     collapseTrigger: SELECTOR_DATA_COLLAPSE,
     removeTrigger: SELECTOR_DATA_REMOVE,
@@ -214,13 +214,13 @@
   var CardWidget = /*#__PURE__*/function () {
     function CardWidget(element, settings) {
       this._element = element;
-      this._parent = element.parents(SELECTOR_CARD$1).first();
+      this._parent = element.parents(SELECTOR_CARD).first();
 
-      if (element.hasClass(CLASS_NAME_CARD$1)) {
+      if (element.hasClass(CLASS_NAME_CARD)) {
         this._parent = element;
       }
 
-      this._settings = $__default['default'].extend({}, Default$1, settings);
+      this._settings = $__default['default'].extend({}, Default$b, settings);
     }
 
     var _proto = CardWidget.prototype;
@@ -229,34 +229,34 @@
       var _this = this;
 
       this._parent.addClass(CLASS_NAME_COLLAPSING).children(SELECTOR_CARD_BODY + ", " + SELECTOR_CARD_FOOTER).slideUp(this._settings.animationSpeed, function () {
-        _this._parent.addClass(CLASS_NAME_COLLAPSED).removeClass(CLASS_NAME_COLLAPSING);
+        _this._parent.addClass(CLASS_NAME_COLLAPSED$1).removeClass(CLASS_NAME_COLLAPSING);
       });
 
       this._parent.find("> " + SELECTOR_CARD_HEADER + " " + this._settings.collapseTrigger + " ." + this._settings.collapseIcon).addClass(this._settings.expandIcon).removeClass(this._settings.collapseIcon);
 
-      this._element.trigger($__default['default'].Event(EVENT_COLLAPSED), this._parent);
+      this._element.trigger($__default['default'].Event(EVENT_COLLAPSED$4), this._parent);
     };
 
     _proto.expand = function expand() {
       var _this2 = this;
 
       this._parent.addClass(CLASS_NAME_EXPANDING).children(SELECTOR_CARD_BODY + ", " + SELECTOR_CARD_FOOTER).slideDown(this._settings.animationSpeed, function () {
-        _this2._parent.removeClass(CLASS_NAME_COLLAPSED).removeClass(CLASS_NAME_EXPANDING);
+        _this2._parent.removeClass(CLASS_NAME_COLLAPSED$1).removeClass(CLASS_NAME_EXPANDING);
       });
 
       this._parent.find("> " + SELECTOR_CARD_HEADER + " " + this._settings.collapseTrigger + " ." + this._settings.expandIcon).addClass(this._settings.collapseIcon).removeClass(this._settings.expandIcon);
 
-      this._element.trigger($__default['default'].Event(EVENT_EXPANDED), this._parent);
+      this._element.trigger($__default['default'].Event(EVENT_EXPANDED$3), this._parent);
     };
 
     _proto.remove = function remove() {
       this._parent.slideUp();
 
-      this._element.trigger($__default['default'].Event(EVENT_REMOVED), this._parent);
+      this._element.trigger($__default['default'].Event(EVENT_REMOVED$1), this._parent);
     };
 
     _proto.toggle = function toggle() {
-      if (this._parent.hasClass(CLASS_NAME_COLLAPSED)) {
+      if (this._parent.hasClass(CLASS_NAME_COLLAPSED$1)) {
         this.expand();
         return;
       }
@@ -276,7 +276,7 @@
         $element.addClass(CLASS_NAME_MAXIMIZED);
         $__default['default']('html').addClass(CLASS_NAME_MAXIMIZED);
 
-        if ($element.hasClass(CLASS_NAME_COLLAPSED)) {
+        if ($element.hasClass(CLASS_NAME_COLLAPSED$1)) {
           $element.addClass(CLASS_NAME_WAS_COLLAPSED);
         }
 
@@ -335,16 +335,16 @@
     ;
 
     CardWidget._jQueryInterface = function _jQueryInterface(config) {
-      var data = $__default['default'](this).data(DATA_KEY$1);
+      var data = $__default['default'](this).data(DATA_KEY$d);
 
-      var _options = $__default['default'].extend({}, Default$1, $__default['default'](this).data());
+      var _options = $__default['default'].extend({}, Default$b, $__default['default'](this).data());
 
       if (!data) {
         data = new CardWidget($__default['default'](this), _options);
-        $__default['default'](this).data(DATA_KEY$1, typeof config === 'string' ? data : config);
+        $__default['default'](this).data(DATA_KEY$d, typeof config === 'string' ? data : config);
       }
 
-      if (typeof config === 'string' && config.match(/collapse|expand|remove|toggle|maximize|minimize|toggleMaximize/)) {
+      if (typeof config === 'string' && /collapse|expand|remove|toggle|maximize|minimize|toggleMaximize/.test(config)) {
         data[config]();
       } else if (typeof config === 'object') {
         data._init($__default['default'](this));
@@ -385,11 +385,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$1] = CardWidget._jQueryInterface;
-  $__default['default'].fn[NAME$1].Constructor = CardWidget;
+  $__default['default'].fn[NAME$d] = CardWidget._jQueryInterface;
+  $__default['default'].fn[NAME$d].Constructor = CardWidget;
 
-  $__default['default'].fn[NAME$1].noConflict = function () {
-    $__default['default'].fn[NAME$1] = JQUERY_NO_CONFLICT$1;
+  $__default['default'].fn[NAME$d].noConflict = function () {
+    $__default['default'].fn[NAME$d] = JQUERY_NO_CONFLICT$d;
     return CardWidget._jQueryInterface;
   };
 
@@ -404,21 +404,21 @@
    * ====================================================
    */
 
-  var NAME$2 = 'ControlSidebar';
-  var DATA_KEY$2 = 'lte.controlsidebar';
-  var EVENT_KEY$2 = "." + DATA_KEY$2;
-  var JQUERY_NO_CONFLICT$2 = $__default['default'].fn[NAME$2];
-  var EVENT_COLLAPSED$1 = "collapsed" + EVENT_KEY$2;
-  var EVENT_EXPANDED$1 = "expanded" + EVENT_KEY$2;
+  var NAME$c = 'ControlSidebar';
+  var DATA_KEY$c = 'lte.controlsidebar';
+  var EVENT_KEY$5 = "." + DATA_KEY$c;
+  var JQUERY_NO_CONFLICT$c = $__default['default'].fn[NAME$c];
+  var EVENT_COLLAPSED$3 = "collapsed" + EVENT_KEY$5;
+  var EVENT_EXPANDED$2 = "expanded" + EVENT_KEY$5;
   var SELECTOR_CONTROL_SIDEBAR = '.control-sidebar';
-  var SELECTOR_CONTROL_SIDEBAR_CONTENT = '.control-sidebar-content';
-  var SELECTOR_DATA_TOGGLE = '[data-widget="control-sidebar"]';
-  var SELECTOR_HEADER = '.main-header';
-  var SELECTOR_FOOTER = '.main-footer';
+  var SELECTOR_CONTROL_SIDEBAR_CONTENT$1 = '.control-sidebar-content';
+  var SELECTOR_DATA_TOGGLE$4 = '[data-widget="control-sidebar"]';
+  var SELECTOR_HEADER$1 = '.main-header';
+  var SELECTOR_FOOTER$1 = '.main-footer';
   var CLASS_NAME_CONTROL_SIDEBAR_ANIMATE = 'control-sidebar-animate';
-  var CLASS_NAME_CONTROL_SIDEBAR_OPEN = 'control-sidebar-open';
+  var CLASS_NAME_CONTROL_SIDEBAR_OPEN$1 = 'control-sidebar-open';
   var CLASS_NAME_CONTROL_SIDEBAR_SLIDE = 'control-sidebar-slide-open';
-  var CLASS_NAME_LAYOUT_FIXED = 'layout-fixed';
+  var CLASS_NAME_LAYOUT_FIXED$1 = 'layout-fixed';
   var CLASS_NAME_NAVBAR_FIXED = 'layout-navbar-fixed';
   var CLASS_NAME_NAVBAR_SM_FIXED = 'layout-sm-navbar-fixed';
   var CLASS_NAME_NAVBAR_MD_FIXED = 'layout-md-navbar-fixed';
@@ -429,10 +429,11 @@
   var CLASS_NAME_FOOTER_MD_FIXED = 'layout-md-footer-fixed';
   var CLASS_NAME_FOOTER_LG_FIXED = 'layout-lg-footer-fixed';
   var CLASS_NAME_FOOTER_XL_FIXED = 'layout-xl-footer-fixed';
-  var Default$2 = {
+  var Default$a = {
     controlsidebarSlide: true,
     scrollbarTheme: 'os-theme-light',
-    scrollbarAutoHide: 'l'
+    scrollbarAutoHide: 'l',
+    target: SELECTOR_CONTROL_SIDEBAR
   };
   /**
    * Class Definition
@@ -443,8 +444,6 @@
     function ControlSidebar(element, config) {
       this._element = element;
       this._config = config;
-
-      this._init();
     } // Public
 
 
@@ -452,20 +451,21 @@
 
     _proto.collapse = function collapse() {
       var $body = $__default['default']('body');
-      var $html = $__default['default']('html'); // Show the control sidebar
+      var $html = $__default['default']('html');
+      var target = this._config.target; // Show the control sidebar
 
       if (this._config.controlsidebarSlide) {
         $html.addClass(CLASS_NAME_CONTROL_SIDEBAR_ANIMATE);
         $body.removeClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE).delay(300).queue(function () {
-          $__default['default'](SELECTOR_CONTROL_SIDEBAR).hide();
+          $__default['default'](target).hide();
           $html.removeClass(CLASS_NAME_CONTROL_SIDEBAR_ANIMATE);
           $__default['default'](this).dequeue();
         });
       } else {
-        $body.removeClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN);
+        $body.removeClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1);
       }
 
-      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_COLLAPSED$1));
+      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_COLLAPSED$3));
     };
 
     _proto.show = function show() {
@@ -474,7 +474,7 @@
 
       if (this._config.controlsidebarSlide) {
         $html.addClass(CLASS_NAME_CONTROL_SIDEBAR_ANIMATE);
-        $__default['default'](SELECTOR_CONTROL_SIDEBAR).show().delay(10).queue(function () {
+        $__default['default'](this._config.target).show().delay(10).queue(function () {
           $body.addClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE).delay(300).queue(function () {
             $html.removeClass(CLASS_NAME_CONTROL_SIDEBAR_ANIMATE);
             $__default['default'](this).dequeue();
@@ -482,19 +482,19 @@
           $__default['default'](this).dequeue();
         });
       } else {
-        $body.addClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN);
+        $body.addClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1);
       }
 
       this._fixHeight();
 
       this._fixScrollHeight();
 
-      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_EXPANDED$1));
+      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_EXPANDED$2));
     };
 
     _proto.toggle = function toggle() {
       var $body = $__default['default']('body');
-      var shouldClose = $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE);
+      var shouldClose = $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE);
 
       if (shouldClose) {
         // Close the control sidebar
@@ -509,6 +509,16 @@
     _proto._init = function _init() {
       var _this = this;
 
+      var $body = $__default['default']('body');
+      var shouldNotHideAll = $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE);
+
+      if (shouldNotHideAll) {
+        $__default['default'](SELECTOR_CONTROL_SIDEBAR).not(this._config.target).hide();
+        $__default['default'](this._config.target).css('display', 'block');
+      } else {
+        $__default['default'](SELECTOR_CONTROL_SIDEBAR).hide();
+      }
+
       this._fixHeight();
 
       this._fixScrollHeight();
@@ -520,7 +530,7 @@
       });
       $__default['default'](window).scroll(function () {
         var $body = $__default['default']('body');
-        var shouldFixHeight = $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE);
+        var shouldFixHeight = $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE);
 
         if (shouldFixHeight) {
           _this._fixScrollHeight();
@@ -528,27 +538,37 @@
       });
     };
 
+    _proto._isNavbarFixed = function _isNavbarFixed() {
+      var $body = $__default['default']('body');
+      return $body.hasClass(CLASS_NAME_NAVBAR_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_SM_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_MD_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_LG_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_XL_FIXED);
+    };
+
+    _proto._isFooterFixed = function _isFooterFixed() {
+      var $body = $__default['default']('body');
+      return $body.hasClass(CLASS_NAME_FOOTER_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_SM_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_MD_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_LG_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_XL_FIXED);
+    };
+
     _proto._fixScrollHeight = function _fixScrollHeight() {
       var $body = $__default['default']('body');
+      var $controlSidebar = $__default['default'](this._config.target);
 
-      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED)) {
+      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED$1)) {
         return;
       }
 
       var heights = {
         scroll: $__default['default'](document).height(),
         window: $__default['default'](window).height(),
-        header: $__default['default'](SELECTOR_HEADER).outerHeight(),
-        footer: $__default['default'](SELECTOR_FOOTER).outerHeight()
+        header: $__default['default'](SELECTOR_HEADER$1).outerHeight(),
+        footer: $__default['default'](SELECTOR_FOOTER$1).outerHeight()
       };
       var positions = {
         bottom: Math.abs(heights.window + $__default['default'](window).scrollTop() - heights.scroll),
         top: $__default['default'](window).scrollTop()
       };
-      var navbarFixed = ($body.hasClass(CLASS_NAME_NAVBAR_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_SM_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_MD_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_LG_FIXED) || $body.hasClass(CLASS_NAME_NAVBAR_XL_FIXED)) && $__default['default'](SELECTOR_HEADER).css('position') === 'fixed';
-      var footerFixed = ($body.hasClass(CLASS_NAME_FOOTER_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_SM_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_MD_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_LG_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_XL_FIXED)) && $__default['default'](SELECTOR_FOOTER).css('position') === 'fixed';
-      var $controlSidebar = $__default['default'](SELECTOR_CONTROL_SIDEBAR);
-      var $controlsidebarContent = $__default['default'](SELECTOR_CONTROL_SIDEBAR + ", " + SELECTOR_CONTROL_SIDEBAR + " " + SELECTOR_CONTROL_SIDEBAR_CONTENT);
+      var navbarFixed = this._isNavbarFixed() && $__default['default'](SELECTOR_HEADER$1).css('position') === 'fixed';
+      var footerFixed = this._isFooterFixed() && $__default['default'](SELECTOR_FOOTER$1).css('position') === 'fixed';
+      var $controlsidebarContent = $__default['default'](this._config.target + ", " + this._config.target + " " + SELECTOR_CONTROL_SIDEBAR_CONTENT$1);
 
       if (positions.top === 0 && positions.bottom === 0) {
         $controlSidebar.css({
@@ -577,29 +597,36 @@
       } else {
         $controlSidebar.css('top', heights.header);
       }
+
+      if (footerFixed && navbarFixed) {
+        $controlsidebarContent.css('height', '100%');
+        $controlSidebar.css('height', '');
+      } else if (footerFixed || navbarFixed) {
+        $controlsidebarContent.css('height', '100%');
+        $controlsidebarContent.css('height', '');
+      }
     };
 
     _proto._fixHeight = function _fixHeight() {
       var $body = $__default['default']('body');
+      var $controlSidebar = $__default['default'](this._config.target + " " + SELECTOR_CONTROL_SIDEBAR_CONTENT$1);
 
-      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED)) {
+      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED$1)) {
+        $controlSidebar.attr('style', '');
         return;
       }
 
       var heights = {
         window: $__default['default'](window).height(),
-        header: $__default['default'](SELECTOR_HEADER).outerHeight(),
-        footer: $__default['default'](SELECTOR_FOOTER).outerHeight()
+        header: $__default['default'](SELECTOR_HEADER$1).outerHeight(),
+        footer: $__default['default'](SELECTOR_FOOTER$1).outerHeight()
       };
       var sidebarHeight = heights.window - heights.header;
 
-      if ($body.hasClass(CLASS_NAME_FOOTER_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_SM_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_MD_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_LG_FIXED) || $body.hasClass(CLASS_NAME_FOOTER_XL_FIXED)) {
-        if ($__default['default'](SELECTOR_FOOTER).css('position') === 'fixed') {
-          sidebarHeight = heights.window - heights.header - heights.footer;
-        }
+      if (this._isFooterFixed() && $__default['default'](SELECTOR_FOOTER$1).css('position') === 'fixed') {
+        sidebarHeight = heights.window - heights.header - heights.footer;
       }
 
-      var $controlSidebar = $__default['default'](SELECTOR_CONTROL_SIDEBAR + " " + SELECTOR_CONTROL_SIDEBAR_CONTENT);
       $controlSidebar.css('height', sidebarHeight);
 
       if (typeof $__default['default'].fn.overlayScrollbars !== 'undefined') {
@@ -617,13 +644,13 @@
 
     ControlSidebar._jQueryInterface = function _jQueryInterface(operation) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$2);
+        var data = $__default['default'](this).data(DATA_KEY$c);
 
-        var _options = $__default['default'].extend({}, Default$2, $__default['default'](this).data());
+        var _options = $__default['default'].extend({}, Default$a, $__default['default'](this).data());
 
         if (!data) {
           data = new ControlSidebar(this, _options);
-          $__default['default'](this).data(DATA_KEY$2, data);
+          $__default['default'](this).data(DATA_KEY$c, data);
         }
 
         if (data[operation] === 'undefined') {
@@ -643,21 +670,24 @@
    */
 
 
-  $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE, function (event) {
+  $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE$4, function (event) {
     event.preventDefault();
 
     ControlSidebar._jQueryInterface.call($__default['default'](this), 'toggle');
+  });
+  $__default['default'](document).ready(function () {
+    ControlSidebar._jQueryInterface.call($__default['default'](SELECTOR_DATA_TOGGLE$4), '_init');
   });
   /**
    * jQuery API
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$2] = ControlSidebar._jQueryInterface;
-  $__default['default'].fn[NAME$2].Constructor = ControlSidebar;
+  $__default['default'].fn[NAME$c] = ControlSidebar._jQueryInterface;
+  $__default['default'].fn[NAME$c].Constructor = ControlSidebar;
 
-  $__default['default'].fn[NAME$2].noConflict = function () {
-    $__default['default'].fn[NAME$2] = JQUERY_NO_CONFLICT$2;
+  $__default['default'].fn[NAME$c].noConflict = function () {
+    $__default['default'].fn[NAME$c] = JQUERY_NO_CONFLICT$c;
     return ControlSidebar._jQueryInterface;
   };
 
@@ -672,12 +702,12 @@
    * ====================================================
    */
 
-  var NAME$3 = 'DirectChat';
-  var DATA_KEY$3 = 'lte.directchat';
-  var EVENT_KEY$3 = "." + DATA_KEY$3;
-  var JQUERY_NO_CONFLICT$3 = $__default['default'].fn[NAME$3];
-  var EVENT_TOGGLED = "toggled" + EVENT_KEY$3;
-  var SELECTOR_DATA_TOGGLE$1 = '[data-widget="chat-pane-toggle"]';
+  var NAME$b = 'DirectChat';
+  var DATA_KEY$b = 'lte.directchat';
+  var EVENT_KEY$4 = "." + DATA_KEY$b;
+  var JQUERY_NO_CONFLICT$b = $__default['default'].fn[NAME$b];
+  var EVENT_TOGGLED = "toggled" + EVENT_KEY$4;
+  var SELECTOR_DATA_TOGGLE$3 = '[data-widget="chat-pane-toggle"]';
   var SELECTOR_DIRECT_CHAT = '.direct-chat';
   var CLASS_NAME_DIRECT_CHAT_OPEN = 'direct-chat-contacts-open';
   /**
@@ -700,11 +730,11 @@
 
     DirectChat._jQueryInterface = function _jQueryInterface(config) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$3);
+        var data = $__default['default'](this).data(DATA_KEY$b);
 
         if (!data) {
           data = new DirectChat($__default['default'](this));
-          $__default['default'](this).data(DATA_KEY$3, data);
+          $__default['default'](this).data(DATA_KEY$b, data);
         }
 
         data[config]();
@@ -720,7 +750,7 @@
    */
 
 
-  $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE$1, function (event) {
+  $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE$3, function (event) {
     if (event) {
       event.preventDefault();
     }
@@ -732,11 +762,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$3] = DirectChat._jQueryInterface;
-  $__default['default'].fn[NAME$3].Constructor = DirectChat;
+  $__default['default'].fn[NAME$b] = DirectChat._jQueryInterface;
+  $__default['default'].fn[NAME$b].Constructor = DirectChat;
 
-  $__default['default'].fn[NAME$3].noConflict = function () {
-    $__default['default'].fn[NAME$3] = JQUERY_NO_CONFLICT$3;
+  $__default['default'].fn[NAME$b].noConflict = function () {
+    $__default['default'].fn[NAME$b] = JQUERY_NO_CONFLICT$b;
     return DirectChat._jQueryInterface;
   };
 
@@ -751,9 +781,9 @@
    * ====================================================
    */
 
-  var NAME$4 = 'Dropdown';
-  var DATA_KEY$4 = 'lte.dropdown';
-  var JQUERY_NO_CONFLICT$4 = $__default['default'].fn[NAME$4];
+  var NAME$a = 'Dropdown';
+  var DATA_KEY$a = 'lte.dropdown';
+  var JQUERY_NO_CONFLICT$a = $__default['default'].fn[NAME$a];
   var SELECTOR_NAVBAR = '.navbar';
   var SELECTOR_DROPDOWN_MENU = '.dropdown-menu';
   var SELECTOR_DROPDOWN_MENU_ACTIVE = '.dropdown-menu.show';
@@ -761,7 +791,7 @@
   var CLASS_NAME_DROPDOWN_RIGHT = 'dropdown-menu-right';
   var CLASS_NAME_DROPDOWN_SUBMENU = 'dropdown-submenu'; // TODO: this is unused; should be removed along with the extend?
 
-  var Default$3 = {};
+  var Default$9 = {};
   /**
    * Class Definition
    * ====================================================
@@ -827,13 +857,13 @@
 
     Dropdown._jQueryInterface = function _jQueryInterface(config) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$4);
+        var data = $__default['default'](this).data(DATA_KEY$a);
 
-        var _config = $__default['default'].extend({}, Default$3, $__default['default'](this).data());
+        var _config = $__default['default'].extend({}, Default$9, $__default['default'](this).data());
 
         if (!data) {
           data = new Dropdown($__default['default'](this), _config);
-          $__default['default'](this).data(DATA_KEY$4, data);
+          $__default['default'](this).data(DATA_KEY$a, data);
         }
 
         if (config === 'toggleSubmenu' || config === 'fixPosition') {
@@ -872,11 +902,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$4] = Dropdown._jQueryInterface;
-  $__default['default'].fn[NAME$4].Constructor = Dropdown;
+  $__default['default'].fn[NAME$a] = Dropdown._jQueryInterface;
+  $__default['default'].fn[NAME$a].Constructor = Dropdown;
 
-  $__default['default'].fn[NAME$4].noConflict = function () {
-    $__default['default'].fn[NAME$4] = JQUERY_NO_CONFLICT$4;
+  $__default['default'].fn[NAME$a].noConflict = function () {
+    $__default['default'].fn[NAME$a] = JQUERY_NO_CONFLICT$a;
     return Dropdown._jQueryInterface;
   };
 
@@ -891,13 +921,14 @@
     * ====================================================
     */
 
-  var NAME$5 = 'ExpandableTable';
-  var DATA_KEY$5 = 'lte.expandableTable';
-  var EVENT_KEY$4 = "." + DATA_KEY$5;
-  var JQUERY_NO_CONFLICT$5 = $__default['default'].fn[NAME$5];
-  var EVENT_EXPANDED$2 = "expanded" + EVENT_KEY$4;
-  var EVENT_COLLAPSED$2 = "collapsed" + EVENT_KEY$4;
+  var NAME$9 = 'ExpandableTable';
+  var DATA_KEY$9 = 'lte.expandableTable';
+  var EVENT_KEY$3 = "." + DATA_KEY$9;
+  var JQUERY_NO_CONFLICT$9 = $__default['default'].fn[NAME$9];
+  var EVENT_EXPANDED$1 = "expanded" + EVENT_KEY$3;
+  var EVENT_COLLAPSED$2 = "collapsed" + EVENT_KEY$3;
   var SELECTOR_TABLE = '.expandable-table';
+  var SELECTOR_EXPANDABLE_BODY = '.expandable-body';
   var SELECTOR_DATA_TOGGLE$2 = '[data-widget="expandable-table"]';
   var SELECTOR_ARIA_ATTR = 'aria-expanded';
   /**
@@ -917,7 +948,7 @@
     _proto.init = function init() {
       $__default['default'](SELECTOR_DATA_TOGGLE$2).each(function (_, $header) {
         var $type = $__default['default']($header).attr(SELECTOR_ARIA_ATTR);
-        var $body = $__default['default']($header).next().children().first().children();
+        var $body = $__default['default']($header).next(SELECTOR_EXPANDABLE_BODY).children().first().children();
 
         if ($type === 'true') {
           $body.show();
@@ -932,34 +963,34 @@
       var $element = this._element;
       var time = 500;
       var $type = $element.attr(SELECTOR_ARIA_ATTR);
-      var $body = $element.next().children().first().children();
+      var $body = $element.next(SELECTOR_EXPANDABLE_BODY).children().first().children();
       $body.stop();
 
       if ($type === 'true') {
         $body.slideUp(time, function () {
-          $element.next().addClass('d-none');
+          $element.next(SELECTOR_EXPANDABLE_BODY).addClass('d-none');
         });
         $element.attr(SELECTOR_ARIA_ATTR, 'false');
         $element.trigger($__default['default'].Event(EVENT_COLLAPSED$2));
       } else if ($type === 'false') {
-        $element.next().removeClass('d-none');
+        $element.next(SELECTOR_EXPANDABLE_BODY).removeClass('d-none');
         $body.slideDown(time);
         $element.attr(SELECTOR_ARIA_ATTR, 'true');
-        $element.trigger($__default['default'].Event(EVENT_EXPANDED$2));
+        $element.trigger($__default['default'].Event(EVENT_EXPANDED$1));
       }
     } // Static
     ;
 
     ExpandableTable._jQueryInterface = function _jQueryInterface(operation) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$5);
+        var data = $__default['default'](this).data(DATA_KEY$9);
 
         if (!data) {
           data = new ExpandableTable($__default['default'](this));
-          $__default['default'](this).data(DATA_KEY$5, data);
+          $__default['default'](this).data(DATA_KEY$9, data);
         }
 
-        if (typeof operation === 'string' && operation.match(/init|toggleRow/)) {
+        if (typeof operation === 'string' && /init|toggleRow/.test(operation)) {
           data[operation]();
         }
       });
@@ -984,11 +1015,11 @@
     * ====================================================
     */
 
-  $__default['default'].fn[NAME$5] = ExpandableTable._jQueryInterface;
-  $__default['default'].fn[NAME$5].Constructor = ExpandableTable;
+  $__default['default'].fn[NAME$9] = ExpandableTable._jQueryInterface;
+  $__default['default'].fn[NAME$9].Constructor = ExpandableTable;
 
-  $__default['default'].fn[NAME$5].noConflict = function () {
-    $__default['default'].fn[NAME$5] = JQUERY_NO_CONFLICT$5;
+  $__default['default'].fn[NAME$9].noConflict = function () {
+    $__default['default'].fn[NAME$9] = JQUERY_NO_CONFLICT$9;
     return ExpandableTable._jQueryInterface;
   };
 
@@ -1003,12 +1034,12 @@
    * ====================================================
    */
 
-  var NAME$6 = 'Fullscreen';
-  var DATA_KEY$6 = 'lte.fullscreen';
-  var JQUERY_NO_CONFLICT$6 = $__default['default'].fn[NAME$6];
-  var SELECTOR_DATA_WIDGET = '[data-widget="fullscreen"]';
-  var SELECTOR_ICON = SELECTOR_DATA_WIDGET + " i";
-  var Default$4 = {
+  var NAME$8 = 'Fullscreen';
+  var DATA_KEY$8 = 'lte.fullscreen';
+  var JQUERY_NO_CONFLICT$8 = $__default['default'].fn[NAME$8];
+  var SELECTOR_DATA_WIDGET$2 = '[data-widget="fullscreen"]';
+  var SELECTOR_ICON = SELECTOR_DATA_WIDGET$2 + " i";
+  var Default$8 = {
     minimizeIcon: 'fa-compress-arrows-alt',
     maximizeIcon: 'fa-expand-arrows-alt'
   };
@@ -1020,7 +1051,7 @@
   var Fullscreen = /*#__PURE__*/function () {
     function Fullscreen(_element, _options) {
       this.element = _element;
-      this.options = $__default['default'].extend({}, Default$4, _options);
+      this.options = $__default['default'].extend({}, Default$8, _options);
     } // Public
 
 
@@ -1060,18 +1091,18 @@
     ;
 
     Fullscreen._jQueryInterface = function _jQueryInterface(config) {
-      var data = $__default['default'](this).data(DATA_KEY$6);
+      var data = $__default['default'](this).data(DATA_KEY$8);
 
       if (!data) {
         data = $__default['default'](this).data();
       }
 
-      var _options = $__default['default'].extend({}, Default$4, typeof config === 'object' ? config : data);
+      var _options = $__default['default'].extend({}, Default$8, typeof config === 'object' ? config : data);
 
       var plugin = new Fullscreen($__default['default'](this), _options);
-      $__default['default'](this).data(DATA_KEY$6, typeof config === 'object' ? config : data);
+      $__default['default'](this).data(DATA_KEY$8, typeof config === 'object' ? config : data);
 
-      if (typeof config === 'string' && config.match(/toggle|fullscreen|windowed/)) {
+      if (typeof config === 'string' && /toggle|fullscreen|windowed/.test(config)) {
         plugin[config]();
       } else {
         plugin.init();
@@ -1086,7 +1117,7 @@
     */
 
 
-  $__default['default'](document).on('click', SELECTOR_DATA_WIDGET, function () {
+  $__default['default'](document).on('click', SELECTOR_DATA_WIDGET$2, function () {
     Fullscreen._jQueryInterface.call($__default['default'](this), 'toggle');
   });
   /**
@@ -1094,11 +1125,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$6] = Fullscreen._jQueryInterface;
-  $__default['default'].fn[NAME$6].Constructor = Fullscreen;
+  $__default['default'].fn[NAME$8] = Fullscreen._jQueryInterface;
+  $__default['default'].fn[NAME$8].Constructor = Fullscreen;
 
-  $__default['default'].fn[NAME$6].noConflict = function () {
-    $__default['default'].fn[NAME$6] = JQUERY_NO_CONFLICT$6;
+  $__default['default'].fn[NAME$8].noConflict = function () {
+    $__default['default'].fn[NAME$8] = JQUERY_NO_CONFLICT$8;
     return Fullscreen._jQueryInterface;
   };
 
@@ -1116,25 +1147,28 @@
   var NAME$7 = 'IFrame';
   var DATA_KEY$7 = 'lte.iframe';
   var JQUERY_NO_CONFLICT$7 = $__default['default'].fn[NAME$7];
-  var SELECTOR_DATA_TOGGLE$3 = '[data-widget="iframe"]';
+  var SELECTOR_DATA_TOGGLE$1 = '[data-widget="iframe"]';
   var SELECTOR_DATA_TOGGLE_CLOSE = '[data-widget="iframe-close"]';
   var SELECTOR_DATA_TOGGLE_SCROLL_LEFT = '[data-widget="iframe-scrollleft"]';
   var SELECTOR_DATA_TOGGLE_SCROLL_RIGHT = '[data-widget="iframe-scrollright"]';
   var SELECTOR_DATA_TOGGLE_FULLSCREEN = '[data-widget="iframe-fullscreen"]';
   var SELECTOR_CONTENT_WRAPPER = '.content-wrapper';
   var SELECTOR_CONTENT_IFRAME = SELECTOR_CONTENT_WRAPPER + " iframe";
-  var SELECTOR_TAB_NAV = SELECTOR_DATA_TOGGLE$3 + ".iframe-mode .nav";
-  var SELECTOR_TAB_NAVBAR_NAV = SELECTOR_DATA_TOGGLE$3 + ".iframe-mode .navbar-nav";
+  var SELECTOR_TAB_NAV = SELECTOR_DATA_TOGGLE$1 + ".iframe-mode .nav";
+  var SELECTOR_TAB_NAVBAR_NAV = SELECTOR_DATA_TOGGLE$1 + ".iframe-mode .navbar-nav";
   var SELECTOR_TAB_NAVBAR_NAV_ITEM = SELECTOR_TAB_NAVBAR_NAV + " .nav-item";
-  var SELECTOR_TAB_CONTENT = SELECTOR_DATA_TOGGLE$3 + ".iframe-mode .tab-content";
+  var SELECTOR_TAB_NAVBAR_NAV_LINK = SELECTOR_TAB_NAVBAR_NAV + " .nav-link";
+  var SELECTOR_TAB_CONTENT = SELECTOR_DATA_TOGGLE$1 + ".iframe-mode .tab-content";
   var SELECTOR_TAB_EMPTY = SELECTOR_TAB_CONTENT + " .tab-empty";
   var SELECTOR_TAB_LOADING = SELECTOR_TAB_CONTENT + " .tab-loading";
+  var SELECTOR_TAB_PANE = SELECTOR_TAB_CONTENT + " .tab-pane";
   var SELECTOR_SIDEBAR_MENU_ITEM = '.main-sidebar .nav-item > a.nav-link';
+  var SELECTOR_SIDEBAR_SEARCH_ITEM = '.sidebar-search-results .list-group-item';
   var SELECTOR_HEADER_MENU_ITEM = '.main-header .nav-item a.nav-link';
   var SELECTOR_HEADER_DROPDOWN_ITEM = '.main-header a.dropdown-item';
   var CLASS_NAME_IFRAME_MODE = 'iframe-mode';
   var CLASS_NAME_FULLSCREEN_MODE = 'iframe-mode-fullscreen';
-  var Default$5 = {
+  var Default$7 = {
     onTabClick: function onTabClick(item) {
       return item;
     },
@@ -1147,6 +1181,7 @@
     autoIframeMode: true,
     autoItemActive: true,
     autoShowNewTab: true,
+    allowDuplicates: false,
     loadingScreen: true,
     useNavbarItems: true,
     scrollOffset: 40,
@@ -1185,12 +1220,18 @@
     _proto.createTab = function createTab(title, link, uniqueName, autoOpen) {
       var _this = this;
 
-      var tabId = "panel-" + uniqueName + "-" + Math.floor(Math.random() * 1000);
-      var navId = "tab-" + uniqueName + "-" + Math.floor(Math.random() * 1000);
-      var newNavItem = "<li class=\"nav-item\" role=\"presentation\"><a class=\"nav-link\" data-toggle=\"row\" id=\"" + navId + "\" href=\"#" + tabId + "\" role=\"tab\" aria-controls=\"" + tabId + "\" aria-selected=\"false\">" + title + "</a></li>";
-      $__default['default'](SELECTOR_TAB_NAVBAR_NAV).append(newNavItem);
+      var tabId = "panel-" + uniqueName;
+      var navId = "tab-" + uniqueName;
+
+      if (this._config.allowDuplicates) {
+        tabId += "-" + Math.floor(Math.random() * 1000);
+        navId += "-" + Math.floor(Math.random() * 1000);
+      }
+
+      var newNavItem = "<li class=\"nav-item\" role=\"presentation\"><a href=\"#\" class=\"btn-iframe-close\" data-widget=\"iframe-close\" data-type=\"only-this\"><i class=\"fas fa-times\"></i></a><a class=\"nav-link\" data-toggle=\"row\" id=\"" + navId + "\" href=\"#" + tabId + "\" role=\"tab\" aria-controls=\"" + tabId + "\" aria-selected=\"false\">" + title + "</a></li>";
+      $__default['default'](SELECTOR_TAB_NAVBAR_NAV).append(unescape(escape(newNavItem)));
       var newTabItem = "<div class=\"tab-pane fade\" id=\"" + tabId + "\" role=\"tabpanel\" aria-labelledby=\"" + navId + "\"><iframe src=\"" + link + "\"></iframe></div>";
-      $__default['default'](SELECTOR_TAB_CONTENT).append(newTabItem);
+      $__default['default'](SELECTOR_TAB_CONTENT).append(unescape(escape(newTabItem)));
 
       if (autoOpen) {
         if (this._config.loadingScreen) {
@@ -1198,13 +1239,13 @@
           $loadingScreen.fadeIn();
           $__default['default'](tabId + " iframe").ready(function () {
             if (typeof _this._config.loadingScreen === 'number') {
-              _this.switchTab("#" + navId, _this._config.loadingScreen);
+              _this.switchTab("#" + navId);
 
               setTimeout(function () {
                 $loadingScreen.fadeOut();
               }, _this._config.loadingScreen);
             } else {
-              _this.switchTab("#" + navId, _this._config.loadingScreen);
+              _this.switchTab("#" + navId);
 
               $loadingScreen.fadeOut();
             }
@@ -1228,7 +1269,7 @@
         $item = $__default['default'](item).parent('a').clone();
       }
 
-      $item.find('.right').remove();
+      $item.find('.right, .search-path').remove();
       var title = $item.find('p').text();
 
       if (title === '') {
@@ -1241,7 +1282,16 @@
         return;
       }
 
-      this.createTab(title, link, link.replace('.html', '').replace('./', '').replaceAll('/', '-'), autoOpen);
+      var uniqueName = link.replace('./', '').replace(/["&'./:=?[\]]/gi, '-').replace(/(--)/gi, '');
+      var navId = "tab-" + uniqueName;
+
+      if (!this._config.allowDuplicates && $__default['default']("#" + navId).length > 0) {
+        return this.switchTab("#" + navId);
+      }
+
+      if (!this._config.allowDuplicates && $__default['default']("#" + navId).length === 0 || this._config.allowDuplicates) {
+        this.createTab(title, link, uniqueName, autoOpen);
+      }
     };
 
     _proto.switchTab = function switchTab(item) {
@@ -1261,18 +1311,47 @@
       }
     };
 
-    _proto.removeActiveTab = function removeActiveTab() {
-      var $navItem = $__default['default'](SELECTOR_TAB_NAVBAR_NAV_ITEM + ".active");
-      var $navItemParent = $navItem.parent();
-      var navItemIndex = $navItem.index();
-      $navItem.remove();
-      $__default['default']('.tab-pane.active').remove();
-
-      if ($__default['default'](SELECTOR_TAB_CONTENT).children().length == $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).length) {
+    _proto.removeActiveTab = function removeActiveTab(type, element) {
+      if (type == 'all') {
+        $__default['default'](SELECTOR_TAB_NAVBAR_NAV_ITEM).remove();
+        $__default['default'](SELECTOR_TAB_PANE).remove();
         $__default['default'](SELECTOR_TAB_EMPTY).show();
+      } else if (type == 'all-other') {
+        $__default['default'](SELECTOR_TAB_NAVBAR_NAV_ITEM + ":not(.active)").remove();
+        $__default['default'](SELECTOR_TAB_PANE + ":not(.active)").remove();
+      } else if (type == 'only-this') {
+        var $navClose = $__default['default'](element);
+        var $navItem = $navClose.parent('.nav-item');
+        var $navItemParent = $navItem.parent();
+        var navItemIndex = $navItem.index();
+        var tabId = $navClose.siblings('.nav-link').attr('aria-controls');
+        $navItem.remove();
+        $__default['default']("#" + tabId).remove();
+
+        if ($__default['default'](SELECTOR_TAB_CONTENT).children().length == $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).length) {
+          $__default['default'](SELECTOR_TAB_EMPTY).show();
+        } else {
+          var prevNavItemIndex = navItemIndex - 1;
+          this.switchTab($navItemParent.children().eq(prevNavItemIndex).find('a.nav-link'));
+        }
       } else {
-        var prevNavItemIndex = navItemIndex - 1;
-        this.switchTab($navItemParent.children().eq(prevNavItemIndex).find('a'));
+        var _$navItem = $__default['default'](SELECTOR_TAB_NAVBAR_NAV_ITEM + ".active");
+
+        var _$navItemParent = _$navItem.parent();
+
+        var _navItemIndex = _$navItem.index();
+
+        _$navItem.remove();
+
+        $__default['default'](SELECTOR_TAB_PANE + ".active").remove();
+
+        if ($__default['default'](SELECTOR_TAB_CONTENT).children().length == $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).length) {
+          $__default['default'](SELECTOR_TAB_EMPTY).show();
+        } else {
+          var _prevNavItemIndex = _navItemIndex - 1;
+
+          this.switchTab(_$navItemParent.children().eq(_prevNavItemIndex).find('a.nav-link'));
+        }
       }
     };
 
@@ -1298,6 +1377,13 @@
       if (window.frameElement && this._config.autoIframeMode) {
         $__default['default']('body').addClass(CLASS_NAME_IFRAME_MODE);
       } else if ($__default['default'](SELECTOR_CONTENT_WRAPPER).hasClass(CLASS_NAME_IFRAME_MODE)) {
+        if ($__default['default'](SELECTOR_TAB_CONTENT).children().length > 2) {
+          var $el = $__default['default'](SELECTOR_TAB_PANE + ":first-child");
+          $el.show();
+
+          this._setItemActive($el.find('iframe').attr('src'));
+        }
+
         this._setupListeners();
 
         this._fixHeight(true);
@@ -1319,7 +1405,7 @@
           _this2._fixHeight();
         }, 1);
       });
-      $__default['default'](document).on('click', SELECTOR_SIDEBAR_MENU_ITEM, function (e) {
+      $__default['default'](document).on('click', SELECTOR_SIDEBAR_MENU_ITEM + ", " + SELECTOR_SIDEBAR_SEARCH_ITEM, function (e) {
         e.preventDefault();
 
         _this2.openTabSidebar(e.target);
@@ -1333,7 +1419,14 @@
         });
       }
 
-      $__default['default'](document).on('click', SELECTOR_TAB_NAVBAR_NAV_ITEM, function (e) {
+      $__default['default'](document).on('click', SELECTOR_TAB_NAVBAR_NAV_LINK, function (e) {
+        e.preventDefault();
+
+        _this2.onTabClick(e.target);
+
+        _this2.switchTab(e.target);
+      });
+      $__default['default'](document).on('click', SELECTOR_TAB_NAVBAR_NAV_LINK, function (e) {
         e.preventDefault();
 
         _this2.onTabClick(e.target);
@@ -1342,8 +1435,13 @@
       });
       $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE_CLOSE, function (e) {
         e.preventDefault();
+        var target = e.target;
 
-        _this2.removeActiveTab();
+        if (target.nodeName == 'I') {
+          target = e.target.offsetParent;
+        }
+
+        _this2.removeActiveTab(target.attributes['data-type'] ? target.attributes['data-type'].nodeValue : null, target);
       });
       $__default['default'](document).on('click', SELECTOR_DATA_TOGGLE_FULLSCREEN, function (e) {
         e.preventDefault();
@@ -1420,19 +1518,20 @@
 
       if ($__default['default']('body').hasClass(CLASS_NAME_FULLSCREEN_MODE)) {
         var windowHeight = $__default['default'](window).height();
-        $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).height(windowHeight);
-        $__default['default'](SELECTOR_CONTENT_WRAPPER).height(windowHeight);
-        $__default['default'](SELECTOR_CONTENT_IFRAME).height(windowHeight);
-      } else {
-        var contentWrapperHeight = parseFloat($__default['default'](SELECTOR_CONTENT_WRAPPER).css('min-height'));
         var navbarHeight = $__default['default'](SELECTOR_TAB_NAV).outerHeight();
+        $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING + ", " + SELECTOR_CONTENT_IFRAME).height(windowHeight - navbarHeight);
+        $__default['default'](SELECTOR_CONTENT_WRAPPER).height(windowHeight);
+      } else {
+        var contentWrapperHeight = parseFloat($__default['default'](SELECTOR_CONTENT_WRAPPER).css('height'));
+
+        var _navbarHeight = $__default['default'](SELECTOR_TAB_NAV).outerHeight();
 
         if (tabEmpty == true) {
           setTimeout(function () {
-            $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).height(contentWrapperHeight - navbarHeight);
+            $__default['default'](SELECTOR_TAB_EMPTY + ", " + SELECTOR_TAB_LOADING).height(contentWrapperHeight - _navbarHeight);
           }, 50);
         } else {
-          $__default['default'](SELECTOR_CONTENT_IFRAME).height(contentWrapperHeight - navbarHeight);
+          $__default['default'](SELECTOR_CONTENT_IFRAME).height(contentWrapperHeight - _navbarHeight);
         }
       }
     } // Static
@@ -1441,14 +1540,14 @@
     IFrame._jQueryInterface = function _jQueryInterface(operation) {
       var data = $__default['default'](this).data(DATA_KEY$7);
 
-      var _options = $__default['default'].extend({}, Default$5, $__default['default'](this).data());
+      var _options = $__default['default'].extend({}, Default$7, $__default['default'](this).data());
 
       if (!data) {
         data = new IFrame(this, _options);
         $__default['default'](this).data(DATA_KEY$7, data);
       }
 
-      if (typeof operation === 'string' && operation.match(/createTab|openTabSidebar|switchTab|removeActiveTab/)) {
+      if (typeof operation === 'string' && /createTab|openTabSidebar|switchTab|removeActiveTab/.test(operation)) {
         var _data;
 
         for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
@@ -1468,7 +1567,7 @@
 
 
   $__default['default'](window).on('load', function () {
-    IFrame._jQueryInterface.call($__default['default'](SELECTOR_DATA_TOGGLE$3));
+    IFrame._jQueryInterface.call($__default['default'](SELECTOR_DATA_TOGGLE$1));
   });
   /**
    * jQuery API
@@ -1494,28 +1593,31 @@
    * ====================================================
    */
 
-  var NAME$8 = 'Layout';
-  var DATA_KEY$8 = 'lte.layout';
-  var JQUERY_NO_CONFLICT$8 = $__default['default'].fn[NAME$8];
-  var SELECTOR_HEADER$1 = '.main-header';
+  var NAME$6 = 'Layout';
+  var DATA_KEY$6 = 'lte.layout';
+  var JQUERY_NO_CONFLICT$6 = $__default['default'].fn[NAME$6];
+  var SELECTOR_HEADER = '.main-header';
   var SELECTOR_MAIN_SIDEBAR = '.main-sidebar';
-  var SELECTOR_SIDEBAR = '.main-sidebar .sidebar';
+  var SELECTOR_SIDEBAR$1 = '.main-sidebar .sidebar';
   var SELECTOR_CONTENT = '.content-wrapper';
-  var SELECTOR_CONTROL_SIDEBAR_CONTENT$1 = '.control-sidebar-content';
+  var SELECTOR_CONTROL_SIDEBAR_CONTENT = '.control-sidebar-content';
   var SELECTOR_CONTROL_SIDEBAR_BTN = '[data-widget="control-sidebar"]';
-  var SELECTOR_FOOTER$1 = '.main-footer';
+  var SELECTOR_FOOTER = '.main-footer';
   var SELECTOR_PUSHMENU_BTN = '[data-widget="pushmenu"]';
   var SELECTOR_LOGIN_BOX = '.login-box';
   var SELECTOR_REGISTER_BOX = '.register-box';
+  var SELECTOR_PRELOADER = '.preloader';
+  var CLASS_NAME_SIDEBAR_COLLAPSED$1 = 'sidebar-collapse';
   var CLASS_NAME_SIDEBAR_FOCUSED = 'sidebar-focused';
-  var CLASS_NAME_LAYOUT_FIXED$1 = 'layout-fixed';
+  var CLASS_NAME_LAYOUT_FIXED = 'layout-fixed';
   var CLASS_NAME_CONTROL_SIDEBAR_SLIDE_OPEN = 'control-sidebar-slide-open';
-  var CLASS_NAME_CONTROL_SIDEBAR_OPEN$1 = 'control-sidebar-open';
+  var CLASS_NAME_CONTROL_SIDEBAR_OPEN = 'control-sidebar-open';
   var Default$6 = {
     scrollbarTheme: 'os-theme-light',
     scrollbarAutoHide: 'l',
     panelAutoHeight: true,
     panelAutoHeightMode: 'min-height',
+    preloadDuration: 200,
     loginRegisterAutoHeight: true
   };
   /**
@@ -1527,8 +1629,6 @@
     function Layout(element, config) {
       this._config = config;
       this._element = element;
-
-      this._init();
     } // Public
 
 
@@ -1542,15 +1642,15 @@
       var $body = $__default['default']('body');
       var controlSidebar = 0;
 
-      if ($body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE_OPEN) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN$1) || extra === 'control_sidebar') {
-        controlSidebar = $__default['default'](SELECTOR_CONTROL_SIDEBAR_CONTENT$1).height();
+      if ($body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_SLIDE_OPEN) || $body.hasClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN) || extra === 'control_sidebar') {
+        controlSidebar = $__default['default'](SELECTOR_CONTROL_SIDEBAR_CONTENT).outerHeight();
       }
 
       var heights = {
         window: $__default['default'](window).height(),
-        header: $__default['default'](SELECTOR_HEADER$1).length !== 0 ? $__default['default'](SELECTOR_HEADER$1).outerHeight() : 0,
-        footer: $__default['default'](SELECTOR_FOOTER$1).length !== 0 ? $__default['default'](SELECTOR_FOOTER$1).outerHeight() : 0,
-        sidebar: $__default['default'](SELECTOR_SIDEBAR).length !== 0 ? $__default['default'](SELECTOR_SIDEBAR).height() : 0,
+        header: $__default['default'](SELECTOR_HEADER).length > 0 ? $__default['default'](SELECTOR_HEADER).outerHeight() : 0,
+        footer: $__default['default'](SELECTOR_FOOTER).length > 0 ? $__default['default'](SELECTOR_FOOTER).outerHeight() : 0,
+        sidebar: $__default['default'](SELECTOR_SIDEBAR$1).length > 0 ? $__default['default'](SELECTOR_SIDEBAR$1).height() : 0,
         controlSidebar: controlSidebar
       };
 
@@ -1578,16 +1678,12 @@
         }
       }
 
-      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED$1)) {
+      if (!$body.hasClass(CLASS_NAME_LAYOUT_FIXED)) {
         return;
       }
 
-      if (offset !== false) {
-        $contentSelector.css(this._config.panelAutoHeightMode, max + offset - heights.header - heights.footer);
-      }
-
       if (typeof $__default['default'].fn.overlayScrollbars !== 'undefined') {
-        $__default['default'](SELECTOR_SIDEBAR).overlayScrollbars({
+        $__default['default'](SELECTOR_SIDEBAR$1).overlayScrollbars({
           className: this._config.scrollbarTheme,
           sizeAutoCapable: true,
           scrollbars: {
@@ -1595,6 +1691,8 @@
             clickScrolling: true
           }
         });
+      } else {
+        $__default['default'](SELECTOR_SIDEBAR$1).css('overflow-y', 'auto');
       }
     };
 
@@ -1627,11 +1725,18 @@
         setInterval(this.fixLoginRegisterHeight, this._config.loginRegisterAutoHeight);
       }
 
-      $__default['default'](SELECTOR_SIDEBAR).on('collapsed.lte.treeview expanded.lte.treeview', function () {
+      $__default['default'](SELECTOR_SIDEBAR$1).on('collapsed.lte.treeview expanded.lte.treeview', function () {
         _this.fixLayoutHeight();
       });
+      $__default['default'](SELECTOR_MAIN_SIDEBAR).on('mouseenter mouseleave', function () {
+        if ($__default['default']('body').hasClass(CLASS_NAME_SIDEBAR_COLLAPSED$1)) {
+          _this.fixLayoutHeight();
+        }
+      });
       $__default['default'](SELECTOR_PUSHMENU_BTN).on('collapsed.lte.pushmenu shown.lte.pushmenu', function () {
-        _this.fixLayoutHeight();
+        setTimeout(function () {
+          _this.fixLayoutHeight();
+        }, 300);
       });
       $__default['default'](SELECTOR_CONTROL_SIDEBAR_BTN).on('collapsed.lte.controlsidebar', function () {
         _this.fixLayoutHeight();
@@ -1644,6 +1749,16 @@
       setTimeout(function () {
         $__default['default']('body.hold-transition').removeClass('hold-transition');
       }, 50);
+      setTimeout(function () {
+        var $preloader = $__default['default'](SELECTOR_PRELOADER);
+
+        if ($preloader) {
+          $preloader.css('height', 0);
+          setTimeout(function () {
+            $preloader.children().hide();
+          }, 200);
+        }
+      }, this._config.preloadDuration);
     };
 
     _proto._max = function _max(numbers) {
@@ -1658,7 +1773,7 @@
     };
 
     _proto._isFooterFixed = function _isFooterFixed() {
-      return $__default['default'](SELECTOR_FOOTER$1).css('position') === 'fixed';
+      return $__default['default'](SELECTOR_FOOTER).css('position') === 'fixed';
     } // Static
     ;
 
@@ -1668,13 +1783,13 @@
       }
 
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$8);
+        var data = $__default['default'](this).data(DATA_KEY$6);
 
         var _options = $__default['default'].extend({}, Default$6, $__default['default'](this).data());
 
         if (!data) {
           data = new Layout($__default['default'](this), _options);
-          $__default['default'](this).data(DATA_KEY$8, data);
+          $__default['default'](this).data(DATA_KEY$6, data);
         }
 
         if (config === 'init' || config === '') {
@@ -1696,10 +1811,9 @@
   $__default['default'](window).on('load', function () {
     Layout._jQueryInterface.call($__default['default']('body'));
   });
-  $__default['default'](SELECTOR_SIDEBAR + " a").on('focusin', function () {
+  $__default['default'](SELECTOR_SIDEBAR$1 + " a").on('focusin', function () {
     $__default['default'](SELECTOR_MAIN_SIDEBAR).addClass(CLASS_NAME_SIDEBAR_FOCUSED);
-  });
-  $__default['default'](SELECTOR_SIDEBAR + " a").on('focusout', function () {
+  }).on('focusout', function () {
     $__default['default'](SELECTOR_MAIN_SIDEBAR).removeClass(CLASS_NAME_SIDEBAR_FOCUSED);
   });
   /**
@@ -1707,11 +1821,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$8] = Layout._jQueryInterface;
-  $__default['default'].fn[NAME$8].Constructor = Layout;
+  $__default['default'].fn[NAME$6] = Layout._jQueryInterface;
+  $__default['default'].fn[NAME$6].Constructor = Layout;
 
-  $__default['default'].fn[NAME$8].noConflict = function () {
-    $__default['default'].fn[NAME$8] = JQUERY_NO_CONFLICT$8;
+  $__default['default'].fn[NAME$6].noConflict = function () {
+    $__default['default'].fn[NAME$6] = JQUERY_NO_CONFLICT$6;
     return Layout._jQueryInterface;
   };
 
@@ -1726,21 +1840,21 @@
    * ====================================================
    */
 
-  var NAME$9 = 'PushMenu';
-  var DATA_KEY$9 = 'lte.pushmenu';
-  var EVENT_KEY$5 = "." + DATA_KEY$9;
-  var JQUERY_NO_CONFLICT$9 = $__default['default'].fn[NAME$9];
-  var EVENT_COLLAPSED$3 = "collapsed" + EVENT_KEY$5;
-  var EVENT_SHOWN = "shown" + EVENT_KEY$5;
-  var SELECTOR_TOGGLE_BUTTON = '[data-widget="pushmenu"]';
+  var NAME$5 = 'PushMenu';
+  var DATA_KEY$5 = 'lte.pushmenu';
+  var EVENT_KEY$2 = "." + DATA_KEY$5;
+  var JQUERY_NO_CONFLICT$5 = $__default['default'].fn[NAME$5];
+  var EVENT_COLLAPSED$1 = "collapsed" + EVENT_KEY$2;
+  var EVENT_SHOWN = "shown" + EVENT_KEY$2;
+  var SELECTOR_TOGGLE_BUTTON$1 = '[data-widget="pushmenu"]';
   var SELECTOR_BODY = 'body';
   var SELECTOR_OVERLAY = '#sidebar-overlay';
   var SELECTOR_WRAPPER = '.wrapper';
-  var CLASS_NAME_COLLAPSED$1 = 'sidebar-collapse';
-  var CLASS_NAME_OPEN = 'sidebar-open';
-  var CLASS_NAME_IS_OPENING = 'sidebar-is-opening';
+  var CLASS_NAME_COLLAPSED = 'sidebar-collapse';
+  var CLASS_NAME_OPEN$3 = 'sidebar-open';
+  var CLASS_NAME_IS_OPENING$1 = 'sidebar-is-opening';
   var CLASS_NAME_CLOSED = 'sidebar-closed';
-  var Default$7 = {
+  var Default$5 = {
     autoCollapseSize: 992,
     enableRemember: false,
     noTransitionAfterReload: true
@@ -1753,7 +1867,7 @@
   var PushMenu = /*#__PURE__*/function () {
     function PushMenu(element, options) {
       this._element = element;
-      this._options = $__default['default'].extend({}, Default$7, options);
+      this._options = $__default['default'].extend({}, Default$5, options);
 
       if ($__default['default'](SELECTOR_OVERLAY).length === 0) {
         this._addOverlay();
@@ -1768,19 +1882,17 @@
     _proto.expand = function expand() {
       var $bodySelector = $__default['default'](SELECTOR_BODY);
 
-      if (this._options.autoCollapseSize) {
-        if ($__default['default'](window).width() <= this._options.autoCollapseSize) {
-          $bodySelector.addClass(CLASS_NAME_OPEN);
-        }
+      if (this._options.autoCollapseSize && $__default['default'](window).width() <= this._options.autoCollapseSize) {
+        $bodySelector.addClass(CLASS_NAME_OPEN$3);
       }
 
-      $bodySelector.addClass(CLASS_NAME_IS_OPENING).removeClass(CLASS_NAME_COLLAPSED$1 + " " + CLASS_NAME_CLOSED).delay(50).queue(function () {
-        $bodySelector.removeClass(CLASS_NAME_IS_OPENING);
+      $bodySelector.addClass(CLASS_NAME_IS_OPENING$1).removeClass(CLASS_NAME_COLLAPSED + " " + CLASS_NAME_CLOSED).delay(50).queue(function () {
+        $bodySelector.removeClass(CLASS_NAME_IS_OPENING$1);
         $__default['default'](this).dequeue();
       });
 
       if (this._options.enableRemember) {
-        localStorage.setItem("remember" + EVENT_KEY$5, CLASS_NAME_OPEN);
+        localStorage.setItem("remember" + EVENT_KEY$2, CLASS_NAME_OPEN$3);
       }
 
       $__default['default'](this._element).trigger($__default['default'].Event(EVENT_SHOWN));
@@ -1789,23 +1901,21 @@
     _proto.collapse = function collapse() {
       var $bodySelector = $__default['default'](SELECTOR_BODY);
 
-      if (this._options.autoCollapseSize) {
-        if ($__default['default'](window).width() <= this._options.autoCollapseSize) {
-          $bodySelector.removeClass(CLASS_NAME_OPEN).addClass(CLASS_NAME_CLOSED);
-        }
+      if (this._options.autoCollapseSize && $__default['default'](window).width() <= this._options.autoCollapseSize) {
+        $bodySelector.removeClass(CLASS_NAME_OPEN$3).addClass(CLASS_NAME_CLOSED);
       }
 
-      $bodySelector.addClass(CLASS_NAME_COLLAPSED$1);
+      $bodySelector.addClass(CLASS_NAME_COLLAPSED);
 
       if (this._options.enableRemember) {
-        localStorage.setItem("remember" + EVENT_KEY$5, CLASS_NAME_COLLAPSED$1);
+        localStorage.setItem("remember" + EVENT_KEY$2, CLASS_NAME_COLLAPSED);
       }
 
-      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_COLLAPSED$3));
+      $__default['default'](this._element).trigger($__default['default'].Event(EVENT_COLLAPSED$1));
     };
 
     _proto.toggle = function toggle() {
-      if ($__default['default'](SELECTOR_BODY).hasClass(CLASS_NAME_COLLAPSED$1)) {
+      if ($__default['default'](SELECTOR_BODY).hasClass(CLASS_NAME_COLLAPSED)) {
         this.expand();
       } else {
         this.collapse();
@@ -1824,12 +1934,12 @@
       var $bodySelector = $__default['default'](SELECTOR_BODY);
 
       if ($__default['default'](window).width() <= this._options.autoCollapseSize) {
-        if (!$bodySelector.hasClass(CLASS_NAME_OPEN)) {
+        if (!$bodySelector.hasClass(CLASS_NAME_OPEN$3)) {
           this.collapse();
         }
       } else if (resize === true) {
-        if ($bodySelector.hasClass(CLASS_NAME_OPEN)) {
-          $bodySelector.removeClass(CLASS_NAME_OPEN);
+        if ($bodySelector.hasClass(CLASS_NAME_OPEN$3)) {
+          $bodySelector.removeClass(CLASS_NAME_OPEN$3);
         } else if ($bodySelector.hasClass(CLASS_NAME_CLOSED)) {
           this.expand();
         }
@@ -1842,24 +1952,24 @@
       }
 
       var $body = $__default['default']('body');
-      var toggleState = localStorage.getItem("remember" + EVENT_KEY$5);
+      var toggleState = localStorage.getItem("remember" + EVENT_KEY$2);
 
-      if (toggleState === CLASS_NAME_COLLAPSED$1) {
+      if (toggleState === CLASS_NAME_COLLAPSED) {
         if (this._options.noTransitionAfterReload) {
-          $body.addClass('hold-transition').addClass(CLASS_NAME_COLLAPSED$1).delay(50).queue(function () {
+          $body.addClass('hold-transition').addClass(CLASS_NAME_COLLAPSED).delay(50).queue(function () {
             $__default['default'](this).removeClass('hold-transition');
             $__default['default'](this).dequeue();
           });
         } else {
-          $body.addClass(CLASS_NAME_COLLAPSED$1);
+          $body.addClass(CLASS_NAME_COLLAPSED);
         }
       } else if (this._options.noTransitionAfterReload) {
-        $body.addClass('hold-transition').removeClass(CLASS_NAME_COLLAPSED$1).delay(50).queue(function () {
+        $body.addClass('hold-transition').removeClass(CLASS_NAME_COLLAPSED).delay(50).queue(function () {
           $__default['default'](this).removeClass('hold-transition');
           $__default['default'](this).dequeue();
         });
       } else {
-        $body.removeClass(CLASS_NAME_COLLAPSED$1);
+        $body.removeClass(CLASS_NAME_COLLAPSED);
       }
     } // Private
     ;
@@ -1889,16 +1999,16 @@
 
     PushMenu._jQueryInterface = function _jQueryInterface(operation) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$9);
+        var data = $__default['default'](this).data(DATA_KEY$5);
 
-        var _options = $__default['default'].extend({}, Default$7, $__default['default'](this).data());
+        var _options = $__default['default'].extend({}, Default$5, $__default['default'](this).data());
 
         if (!data) {
           data = new PushMenu(this, _options);
-          $__default['default'](this).data(DATA_KEY$9, data);
+          $__default['default'](this).data(DATA_KEY$5, data);
         }
 
-        if (typeof operation === 'string' && operation.match(/collapse|expand|toggle/)) {
+        if (typeof operation === 'string' && /collapse|expand|toggle/.test(operation)) {
           data[operation]();
         }
       });
@@ -1912,29 +2022,29 @@
    */
 
 
-  $__default['default'](document).on('click', SELECTOR_TOGGLE_BUTTON, function (event) {
+  $__default['default'](document).on('click', SELECTOR_TOGGLE_BUTTON$1, function (event) {
     event.preventDefault();
     var button = event.currentTarget;
 
     if ($__default['default'](button).data('widget') !== 'pushmenu') {
-      button = $__default['default'](button).closest(SELECTOR_TOGGLE_BUTTON);
+      button = $__default['default'](button).closest(SELECTOR_TOGGLE_BUTTON$1);
     }
 
     PushMenu._jQueryInterface.call($__default['default'](button), 'toggle');
   });
   $__default['default'](window).on('load', function () {
-    PushMenu._jQueryInterface.call($__default['default'](SELECTOR_TOGGLE_BUTTON));
+    PushMenu._jQueryInterface.call($__default['default'](SELECTOR_TOGGLE_BUTTON$1));
   });
   /**
    * jQuery API
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$9] = PushMenu._jQueryInterface;
-  $__default['default'].fn[NAME$9].Constructor = PushMenu;
+  $__default['default'].fn[NAME$5] = PushMenu._jQueryInterface;
+  $__default['default'].fn[NAME$5].Constructor = PushMenu;
 
-  $__default['default'].fn[NAME$9].noConflict = function () {
-    $__default['default'].fn[NAME$9] = JQUERY_NO_CONFLICT$9;
+  $__default['default'].fn[NAME$5].noConflict = function () {
+    $__default['default'].fn[NAME$5] = JQUERY_NO_CONFLICT$5;
     return PushMenu._jQueryInterface;
   };
 
@@ -1949,26 +2059,26 @@
    * ====================================================
    */
 
-  var NAME$a = 'SidebarSearch';
-  var DATA_KEY$a = 'lte.sidebar-search';
-  var JQUERY_NO_CONFLICT$a = $__default['default'].fn[NAME$a];
-  var CLASS_NAME_OPEN$1 = 'sidebar-search-open';
+  var NAME$4 = 'SidebarSearch';
+  var DATA_KEY$4 = 'lte.sidebar-search';
+  var JQUERY_NO_CONFLICT$4 = $__default['default'].fn[NAME$4];
+  var CLASS_NAME_OPEN$2 = 'sidebar-search-open';
   var CLASS_NAME_ICON_SEARCH = 'fa-search';
   var CLASS_NAME_ICON_CLOSE = 'fa-times';
   var CLASS_NAME_HEADER = 'nav-header';
   var CLASS_NAME_SEARCH_RESULTS = 'sidebar-search-results';
   var CLASS_NAME_LIST_GROUP = 'list-group';
   var SELECTOR_DATA_WIDGET$1 = '[data-widget="sidebar-search"]';
-  var SELECTOR_SIDEBAR$1 = '.main-sidebar .nav-sidebar';
+  var SELECTOR_SIDEBAR = '.main-sidebar .nav-sidebar';
   var SELECTOR_NAV_LINK = '.nav-link';
   var SELECTOR_NAV_TREEVIEW = '.nav-treeview';
-  var SELECTOR_SEARCH_INPUT = SELECTOR_DATA_WIDGET$1 + " .form-control";
+  var SELECTOR_SEARCH_INPUT$1 = SELECTOR_DATA_WIDGET$1 + " .form-control";
   var SELECTOR_SEARCH_BUTTON = SELECTOR_DATA_WIDGET$1 + " .btn";
   var SELECTOR_SEARCH_ICON = SELECTOR_SEARCH_BUTTON + " i";
   var SELECTOR_SEARCH_LIST_GROUP = "." + CLASS_NAME_LIST_GROUP;
   var SELECTOR_SEARCH_RESULTS = "." + CLASS_NAME_SEARCH_RESULTS;
   var SELECTOR_SEARCH_RESULTS_GROUP = SELECTOR_SEARCH_RESULTS + " ." + CLASS_NAME_LIST_GROUP;
-  var Default$8 = {
+  var Default$4 = {
     arrowSign: '->',
     minLength: 3,
     maxResults: 7,
@@ -1986,7 +2096,7 @@
   var SidebarSearch = /*#__PURE__*/function () {
     function SidebarSearch(_element, _options) {
       this.element = _element;
-      this.options = $__default['default'].extend({}, Default$8, _options);
+      this.options = $__default['default'].extend({}, Default$4, _options);
       this.items = [];
     } // Public
 
@@ -1996,17 +2106,17 @@
     _proto.init = function init() {
       var _this = this;
 
-      if ($__default['default'](SELECTOR_DATA_WIDGET$1).length == 0) {
+      if ($__default['default'](SELECTOR_DATA_WIDGET$1).length === 0) {
         return;
       }
 
-      if ($__default['default'](SELECTOR_DATA_WIDGET$1).next(SELECTOR_SEARCH_RESULTS).length == 0) {
+      if ($__default['default'](SELECTOR_DATA_WIDGET$1).next(SELECTOR_SEARCH_RESULTS).length === 0) {
         $__default['default'](SELECTOR_DATA_WIDGET$1).after($__default['default']('<div />', {
           class: CLASS_NAME_SEARCH_RESULTS
         }));
       }
 
-      if ($__default['default'](SELECTOR_SEARCH_RESULTS).children(SELECTOR_SEARCH_LIST_GROUP).length == 0) {
+      if ($__default['default'](SELECTOR_SEARCH_RESULTS).children(SELECTOR_SEARCH_LIST_GROUP).length === 0) {
         $__default['default'](SELECTOR_SEARCH_RESULTS).append($__default['default']('<div />', {
           class: CLASS_NAME_LIST_GROUP
         }));
@@ -2014,7 +2124,7 @@
 
       this._addNotFound();
 
-      $__default['default'](SELECTOR_SIDEBAR$1).children().each(function (i, child) {
+      $__default['default'](SELECTOR_SIDEBAR).children().each(function (i, child) {
         _this._parseItem(child);
       });
     };
@@ -2022,7 +2132,7 @@
     _proto.search = function search() {
       var _this2 = this;
 
-      var searchValue = $__default['default'](SELECTOR_SEARCH_INPUT).val().toLowerCase();
+      var searchValue = $__default['default'](SELECTOR_SEARCH_INPUT$1).val().toLowerCase();
 
       if (searchValue.length < this.options.minLength) {
         $__default['default'](SELECTOR_SEARCH_RESULTS_GROUP).empty();
@@ -2043,7 +2153,7 @@
         this._addNotFound();
       } else {
         endResults.each(function (i, result) {
-          $__default['default'](SELECTOR_SEARCH_RESULTS_GROUP).append(_this2._renderItem(result.name, result.link, result.path));
+          $__default['default'](SELECTOR_SEARCH_RESULTS_GROUP).append(_this2._renderItem(escape(result.name), escape(result.link), result.path));
         });
       }
 
@@ -2051,17 +2161,17 @@
     };
 
     _proto.open = function open() {
-      $__default['default'](SELECTOR_DATA_WIDGET$1).parent().addClass(CLASS_NAME_OPEN$1);
+      $__default['default'](SELECTOR_DATA_WIDGET$1).parent().addClass(CLASS_NAME_OPEN$2);
       $__default['default'](SELECTOR_SEARCH_ICON).removeClass(CLASS_NAME_ICON_SEARCH).addClass(CLASS_NAME_ICON_CLOSE);
     };
 
     _proto.close = function close() {
-      $__default['default'](SELECTOR_DATA_WIDGET$1).parent().removeClass(CLASS_NAME_OPEN$1);
+      $__default['default'](SELECTOR_DATA_WIDGET$1).parent().removeClass(CLASS_NAME_OPEN$2);
       $__default['default'](SELECTOR_SEARCH_ICON).removeClass(CLASS_NAME_ICON_CLOSE).addClass(CLASS_NAME_ICON_SEARCH);
     };
 
     _proto.toggle = function toggle() {
-      if ($__default['default'](SELECTOR_DATA_WIDGET$1).parent().hasClass(CLASS_NAME_OPEN$1)) {
+      if ($__default['default'](SELECTOR_DATA_WIDGET$1).parent().hasClass(CLASS_NAME_OPEN$2)) {
         this.close();
       } else {
         this.open();
@@ -2107,25 +2217,37 @@
       var _this4 = this;
 
       path = path.join(" " + this.options.arrowSign + " ");
+      name = unescape(name);
 
       if (this.options.highlightName || this.options.highlightPath) {
-        var searchValue = $__default['default'](SELECTOR_SEARCH_INPUT).val().toLowerCase();
+        var searchValue = $__default['default'](SELECTOR_SEARCH_INPUT$1).val().toLowerCase();
         var regExp = new RegExp(searchValue, 'gi');
 
         if (this.options.highlightName) {
           name = name.replace(regExp, function (str) {
-            return "<b class=\"" + _this4.options.highlightClass + "\">" + str + "</b>";
+            return "<strong class=\"" + _this4.options.highlightClass + "\">" + str + "</strong>";
           });
         }
 
         if (this.options.highlightPath) {
           path = path.replace(regExp, function (str) {
-            return "<b class=\"" + _this4.options.highlightClass + "\">" + str + "</b>";
+            return "<strong class=\"" + _this4.options.highlightClass + "\">" + str + "</strong>";
           });
         }
       }
 
-      return "<a href=\"" + link + "\" class=\"list-group-item\">\n        <div class=\"search-title\">\n          " + name + "\n        </div>\n        <div class=\"search-path\">\n          " + path + "\n        </div>\n      </a>";
+      var groupItemElement = $__default['default']('<a/>', {
+        href: link,
+        class: 'list-group-item'
+      });
+      var searchTitleElement = $__default['default']('<div/>', {
+        class: 'search-title'
+      }).html(name);
+      var searchPathElement = $__default['default']('<div/>', {
+        class: 'search-path'
+      }).html(path);
+      groupItemElement.append(searchTitleElement).append(searchPathElement);
+      return groupItemElement;
     };
 
     _proto._addNotFound = function _addNotFound() {
@@ -2134,18 +2256,18 @@
     ;
 
     SidebarSearch._jQueryInterface = function _jQueryInterface(config) {
-      var data = $__default['default'](this).data(DATA_KEY$a);
+      var data = $__default['default'](this).data(DATA_KEY$4);
 
       if (!data) {
         data = $__default['default'](this).data();
       }
 
-      var _options = $__default['default'].extend({}, Default$8, typeof config === 'object' ? config : data);
+      var _options = $__default['default'].extend({}, Default$4, typeof config === 'object' ? config : data);
 
       var plugin = new SidebarSearch($__default['default'](this), _options);
-      $__default['default'](this).data(DATA_KEY$a, typeof config === 'object' ? config : data);
+      $__default['default'](this).data(DATA_KEY$4, typeof config === 'object' ? config : data);
 
-      if (typeof config === 'string' && config.match(/init|toggle|close|open|search/)) {
+      if (typeof config === 'string' && /init|toggle|close|open|search/.test(config)) {
         plugin[config]();
       } else {
         plugin.init();
@@ -2165,7 +2287,7 @@
 
     SidebarSearch._jQueryInterface.call($__default['default'](SELECTOR_DATA_WIDGET$1), 'toggle');
   });
-  $__default['default'](document).on('keyup', SELECTOR_SEARCH_INPUT, function (event) {
+  $__default['default'](document).on('keyup', SELECTOR_SEARCH_INPUT$1, function (event) {
     if (event.keyCode == 38) {
       event.preventDefault();
       $__default['default'](SELECTOR_SEARCH_RESULTS_GROUP).children().last().focus();
@@ -2178,9 +2300,7 @@
       return;
     }
 
-    var timer = 0;
-    clearTimeout(timer);
-    timer = setTimeout(function () {
+    setTimeout(function () {
       SidebarSearch._jQueryInterface.call($__default['default'](SELECTOR_DATA_WIDGET$1), 'search');
     }, 100);
   });
@@ -2215,12 +2335,120 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$a] = SidebarSearch._jQueryInterface;
-  $__default['default'].fn[NAME$a].Constructor = SidebarSearch;
+  $__default['default'].fn[NAME$4] = SidebarSearch._jQueryInterface;
+  $__default['default'].fn[NAME$4].Constructor = SidebarSearch;
 
-  $__default['default'].fn[NAME$a].noConflict = function () {
-    $__default['default'].fn[NAME$a] = JQUERY_NO_CONFLICT$a;
+  $__default['default'].fn[NAME$4].noConflict = function () {
+    $__default['default'].fn[NAME$4] = JQUERY_NO_CONFLICT$4;
     return SidebarSearch._jQueryInterface;
+  };
+
+  /**
+   * --------------------------------------------
+   * AdminLTE NavbarSearch.js
+   * License MIT
+   * --------------------------------------------
+   */
+  /**
+   * Constants
+   * ====================================================
+   */
+
+  var NAME$3 = 'NavbarSearch';
+  var DATA_KEY$3 = 'lte.navbar-search';
+  var JQUERY_NO_CONFLICT$3 = $__default['default'].fn[NAME$3];
+  var SELECTOR_TOGGLE_BUTTON = '[data-widget="navbar-search"]';
+  var SELECTOR_SEARCH_BLOCK = '.navbar-search-block';
+  var SELECTOR_SEARCH_INPUT = '.form-control';
+  var CLASS_NAME_OPEN$1 = 'navbar-search-open';
+  var Default$3 = {
+    resetOnClose: true,
+    target: SELECTOR_SEARCH_BLOCK
+  };
+  /**
+   * Class Definition
+   * ====================================================
+   */
+
+  var NavbarSearch = /*#__PURE__*/function () {
+    function NavbarSearch(_element, _options) {
+      this._element = _element;
+      this._config = $__default['default'].extend({}, Default$3, _options);
+    } // Public
+
+
+    var _proto = NavbarSearch.prototype;
+
+    _proto.open = function open() {
+      $__default['default'](this._config.target).css('display', 'flex').hide().fadeIn().addClass(CLASS_NAME_OPEN$1);
+      $__default['default'](this._config.target + " " + SELECTOR_SEARCH_INPUT).focus();
+    };
+
+    _proto.close = function close() {
+      $__default['default'](this._config.target).fadeOut().removeClass(CLASS_NAME_OPEN$1);
+
+      if (this._config.resetOnClose) {
+        $__default['default'](this._config.target + " " + SELECTOR_SEARCH_INPUT).val('');
+      }
+    };
+
+    _proto.toggle = function toggle() {
+      if ($__default['default'](this._config.target).hasClass(CLASS_NAME_OPEN$1)) {
+        this.close();
+      } else {
+        this.open();
+      }
+    } // Static
+    ;
+
+    NavbarSearch._jQueryInterface = function _jQueryInterface(options) {
+      return this.each(function () {
+        var data = $__default['default'](this).data(DATA_KEY$3);
+
+        var _options = $__default['default'].extend({}, Default$3, $__default['default'](this).data());
+
+        if (!data) {
+          data = new NavbarSearch(this, _options);
+          $__default['default'](this).data(DATA_KEY$3, data);
+        }
+
+        if (!/toggle|close|open/.test(options)) {
+          throw new Error("Undefined method " + options);
+        }
+
+        data[options]();
+      });
+    };
+
+    return NavbarSearch;
+  }();
+  /**
+   * Data API
+   * ====================================================
+   */
+
+
+  $__default['default'](document).on('click', SELECTOR_TOGGLE_BUTTON, function (event) {
+    event.preventDefault();
+    var button = $__default['default'](event.currentTarget);
+
+    if (button.data('widget') !== 'navbar-search') {
+      button = button.closest(SELECTOR_TOGGLE_BUTTON);
+    }
+
+    NavbarSearch._jQueryInterface.call(button, 'toggle');
+  });
+  /**
+   * jQuery API
+   * ====================================================
+   */
+
+  $__default['default'].fn[NAME$3] = NavbarSearch._jQueryInterface;
+  $__default['default'].fn[NAME$3].Constructor = NavbarSearch;
+
+  $__default['default'].fn[NAME$3].noConflict = function () {
+    $__default['default'].fn[NAME$3] = JQUERY_NO_CONFLICT$3;
+    return NavbarSearch._jQueryInterface;
   };
 
   /**
@@ -2234,13 +2462,13 @@
    * ====================================================
    */
 
-  var NAME$b = 'Toasts';
-  var DATA_KEY$b = 'lte.toasts';
-  var EVENT_KEY$6 = "." + DATA_KEY$b;
-  var JQUERY_NO_CONFLICT$b = $__default['default'].fn[NAME$b];
-  var EVENT_INIT = "init" + EVENT_KEY$6;
-  var EVENT_CREATED = "created" + EVENT_KEY$6;
-  var EVENT_REMOVED$1 = "removed" + EVENT_KEY$6;
+  var NAME$2 = 'Toasts';
+  var DATA_KEY$2 = 'lte.toasts';
+  var EVENT_KEY$1 = "." + DATA_KEY$2;
+  var JQUERY_NO_CONFLICT$2 = $__default['default'].fn[NAME$2];
+  var EVENT_INIT = "init" + EVENT_KEY$1;
+  var EVENT_CREATED = "created" + EVENT_KEY$1;
+  var EVENT_REMOVED = "removed" + EVENT_KEY$1;
   var SELECTOR_CONTAINER_TOP_RIGHT = '#toastsContainerTopRight';
   var SELECTOR_CONTAINER_TOP_LEFT = '#toastsContainerTopLeft';
   var SELECTOR_CONTAINER_BOTTOM_RIGHT = '#toastsContainerBottomRight';
@@ -2253,7 +2481,7 @@
   var POSITION_TOP_LEFT = 'topLeft';
   var POSITION_BOTTOM_RIGHT = 'bottomRight';
   var POSITION_BOTTOM_LEFT = 'bottomLeft';
-  var Default$9 = {
+  var Default$2 = {
     position: POSITION_TOP_RIGHT,
     fixed: true,
     autohide: false,
@@ -2348,7 +2576,7 @@
       if (this._config.autoremove) {
         toast.on('hidden.bs.toast', function () {
           $__default['default'](this).delay(200).remove();
-          $body.trigger($__default['default'].Event(EVENT_REMOVED$1));
+          $body.trigger($__default['default'].Event(EVENT_REMOVED));
         });
       }
     } // Static
@@ -2399,7 +2627,7 @@
 
     Toasts._jQueryInterface = function _jQueryInterface(option, config) {
       return this.each(function () {
-        var _options = $__default['default'].extend({}, Default$9, config);
+        var _options = $__default['default'].extend({}, Default$2, config);
 
         var toast = new Toasts($__default['default'](this), _options);
 
@@ -2417,11 +2645,11 @@
    */
 
 
-  $__default['default'].fn[NAME$b] = Toasts._jQueryInterface;
-  $__default['default'].fn[NAME$b].Constructor = Toasts;
+  $__default['default'].fn[NAME$2] = Toasts._jQueryInterface;
+  $__default['default'].fn[NAME$2].Constructor = Toasts;
 
-  $__default['default'].fn[NAME$b].noConflict = function () {
-    $__default['default'].fn[NAME$b] = JQUERY_NO_CONFLICT$b;
+  $__default['default'].fn[NAME$2].noConflict = function () {
+    $__default['default'].fn[NAME$2] = JQUERY_NO_CONFLICT$2;
     return Toasts._jQueryInterface;
   };
 
@@ -2436,12 +2664,12 @@
    * ====================================================
    */
 
-  var NAME$c = 'TodoList';
-  var DATA_KEY$c = 'lte.todolist';
-  var JQUERY_NO_CONFLICT$c = $__default['default'].fn[NAME$c];
-  var SELECTOR_DATA_TOGGLE$4 = '[data-widget="todo-list"]';
+  var NAME$1 = 'TodoList';
+  var DATA_KEY$1 = 'lte.todolist';
+  var JQUERY_NO_CONFLICT$1 = $__default['default'].fn[NAME$1];
+  var SELECTOR_DATA_TOGGLE = '[data-widget="todo-list"]';
   var CLASS_NAME_TODO_LIST_DONE = 'done';
-  var Default$a = {
+  var Default$1 = {
     onCheck: function onCheck(item) {
       return item;
     },
@@ -2498,16 +2726,16 @@
 
     TodoList._jQueryInterface = function _jQueryInterface(config) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$c);
+        var data = $__default['default'](this).data(DATA_KEY$1);
 
         if (!data) {
           data = $__default['default'](this).data();
         }
 
-        var _options = $__default['default'].extend({}, Default$a, typeof config === 'object' ? config : data);
+        var _options = $__default['default'].extend({}, Default$1, typeof config === 'object' ? config : data);
 
         var plugin = new TodoList($__default['default'](this), _options);
-        $__default['default'](this).data(DATA_KEY$c, typeof config === 'object' ? config : data);
+        $__default['default'](this).data(DATA_KEY$1, typeof config === 'object' ? config : data);
 
         if (config === 'init') {
           plugin[config]();
@@ -2524,18 +2752,18 @@
 
 
   $__default['default'](window).on('load', function () {
-    TodoList._jQueryInterface.call($__default['default'](SELECTOR_DATA_TOGGLE$4));
+    TodoList._jQueryInterface.call($__default['default'](SELECTOR_DATA_TOGGLE));
   });
   /**
    * jQuery API
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$c] = TodoList._jQueryInterface;
-  $__default['default'].fn[NAME$c].Constructor = TodoList;
+  $__default['default'].fn[NAME$1] = TodoList._jQueryInterface;
+  $__default['default'].fn[NAME$1].Constructor = TodoList;
 
-  $__default['default'].fn[NAME$c].noConflict = function () {
-    $__default['default'].fn[NAME$c] = JQUERY_NO_CONFLICT$c;
+  $__default['default'].fn[NAME$1].noConflict = function () {
+    $__default['default'].fn[NAME$1] = JQUERY_NO_CONFLICT$1;
     return TodoList._jQueryInterface;
   };
 
@@ -2550,23 +2778,23 @@
    * ====================================================
    */
 
-  var NAME$d = 'Treeview';
-  var DATA_KEY$d = 'lte.treeview';
-  var EVENT_KEY$7 = "." + DATA_KEY$d;
-  var JQUERY_NO_CONFLICT$d = $__default['default'].fn[NAME$d];
-  var EVENT_EXPANDED$3 = "expanded" + EVENT_KEY$7;
-  var EVENT_COLLAPSED$4 = "collapsed" + EVENT_KEY$7;
-  var EVENT_LOAD_DATA_API = "load" + EVENT_KEY$7;
+  var NAME = 'Treeview';
+  var DATA_KEY = 'lte.treeview';
+  var EVENT_KEY = "." + DATA_KEY;
+  var JQUERY_NO_CONFLICT = $__default['default'].fn[NAME];
+  var EVENT_EXPANDED = "expanded" + EVENT_KEY;
+  var EVENT_COLLAPSED = "collapsed" + EVENT_KEY;
+  var EVENT_LOAD_DATA_API = "load" + EVENT_KEY;
   var SELECTOR_LI = '.nav-item';
   var SELECTOR_LINK = '.nav-link';
   var SELECTOR_TREEVIEW_MENU = '.nav-treeview';
   var SELECTOR_OPEN = '.menu-open';
-  var SELECTOR_DATA_WIDGET$2 = '[data-widget="treeview"]';
-  var CLASS_NAME_OPEN$2 = 'menu-open';
-  var CLASS_NAME_IS_OPENING$1 = 'menu-is-opening';
+  var SELECTOR_DATA_WIDGET = '[data-widget="treeview"]';
+  var CLASS_NAME_OPEN = 'menu-open';
+  var CLASS_NAME_IS_OPENING = 'menu-is-opening';
   var CLASS_NAME_SIDEBAR_COLLAPSED = 'sidebar-collapse';
-  var Default$b = {
-    trigger: SELECTOR_DATA_WIDGET$2 + " " + SELECTOR_LINK,
+  var Default = {
+    trigger: SELECTOR_DATA_WIDGET + " " + SELECTOR_LINK,
     animationSpeed: 300,
     accordion: true,
     expandSidebar: false,
@@ -2587,7 +2815,7 @@
     var _proto = Treeview.prototype;
 
     _proto.init = function init() {
-      $__default['default']("" + SELECTOR_LI + SELECTOR_OPEN + " " + SELECTOR_TREEVIEW_MENU).css('display', 'block');
+      $__default['default']("" + SELECTOR_LI + SELECTOR_OPEN + " " + SELECTOR_TREEVIEW_MENU + SELECTOR_OPEN).css('display', 'block');
 
       this._setupListeners();
     };
@@ -2595,7 +2823,7 @@
     _proto.expand = function expand(treeviewMenu, parentLi) {
       var _this = this;
 
-      var expandedEvent = $__default['default'].Event(EVENT_EXPANDED$3);
+      var expandedEvent = $__default['default'].Event(EVENT_EXPANDED);
 
       if (this._config.accordion) {
         var openMenuLi = parentLi.siblings(SELECTOR_OPEN).first();
@@ -2603,9 +2831,9 @@
         this.collapse(openTreeview, openMenuLi);
       }
 
-      parentLi.addClass(CLASS_NAME_IS_OPENING$1);
+      parentLi.addClass(CLASS_NAME_IS_OPENING);
       treeviewMenu.stop().slideDown(this._config.animationSpeed, function () {
-        parentLi.addClass(CLASS_NAME_OPEN$2);
+        parentLi.addClass(CLASS_NAME_OPEN);
         $__default['default'](_this._element).trigger(expandedEvent);
       });
 
@@ -2617,12 +2845,12 @@
     _proto.collapse = function collapse(treeviewMenu, parentLi) {
       var _this2 = this;
 
-      var collapsedEvent = $__default['default'].Event(EVENT_COLLAPSED$4);
-      parentLi.removeClass(CLASS_NAME_IS_OPENING$1 + " " + CLASS_NAME_OPEN$2);
+      var collapsedEvent = $__default['default'].Event(EVENT_COLLAPSED);
+      parentLi.removeClass(CLASS_NAME_IS_OPENING + " " + CLASS_NAME_OPEN);
       treeviewMenu.stop().slideUp(this._config.animationSpeed, function () {
         $__default['default'](_this2._element).trigger(collapsedEvent);
         treeviewMenu.find(SELECTOR_OPEN + " > " + SELECTOR_TREEVIEW_MENU).slideUp();
-        treeviewMenu.find(SELECTOR_OPEN).removeClass(CLASS_NAME_OPEN$2);
+        treeviewMenu.find(SELECTOR_OPEN).removeClass(CLASS_NAME_OPEN);
       });
     };
 
@@ -2643,7 +2871,7 @@
 
       event.preventDefault();
       var parentLi = $relativeTarget.parents(SELECTOR_LI).first();
-      var isOpen = parentLi.hasClass(CLASS_NAME_OPEN$2);
+      var isOpen = parentLi.hasClass(CLASS_NAME_OPEN);
 
       if (isOpen) {
         this.collapse($__default['default'](treeviewMenu), parentLi);
@@ -2671,13 +2899,13 @@
 
     Treeview._jQueryInterface = function _jQueryInterface(config) {
       return this.each(function () {
-        var data = $__default['default'](this).data(DATA_KEY$d);
+        var data = $__default['default'](this).data(DATA_KEY);
 
-        var _options = $__default['default'].extend({}, Default$b, $__default['default'](this).data());
+        var _options = $__default['default'].extend({}, Default, $__default['default'](this).data());
 
         if (!data) {
           data = new Treeview($__default['default'](this), _options);
-          $__default['default'](this).data(DATA_KEY$d, data);
+          $__default['default'](this).data(DATA_KEY, data);
         }
 
         if (config === 'init') {
@@ -2695,7 +2923,7 @@
 
 
   $__default['default'](window).on(EVENT_LOAD_DATA_API, function () {
-    $__default['default'](SELECTOR_DATA_WIDGET$2).each(function () {
+    $__default['default'](SELECTOR_DATA_WIDGET).each(function () {
       Treeview._jQueryInterface.call($__default['default'](this), 'init');
     });
   });
@@ -2704,11 +2932,11 @@
    * ====================================================
    */
 
-  $__default['default'].fn[NAME$d] = Treeview._jQueryInterface;
-  $__default['default'].fn[NAME$d].Constructor = Treeview;
+  $__default['default'].fn[NAME] = Treeview._jQueryInterface;
+  $__default['default'].fn[NAME].Constructor = Treeview;
 
-  $__default['default'].fn[NAME$d].noConflict = function () {
-    $__default['default'].fn[NAME$d] = JQUERY_NO_CONFLICT$d;
+  $__default['default'].fn[NAME].noConflict = function () {
+    $__default['default'].fn[NAME] = JQUERY_NO_CONFLICT;
     return Treeview._jQueryInterface;
   };
 
@@ -2721,6 +2949,7 @@
   exports.Fullscreen = Fullscreen;
   exports.IFrame = IFrame;
   exports.Layout = Layout;
+  exports.NavbarSearch = NavbarSearch;
   exports.PushMenu = PushMenu;
   exports.SidebarSearch = SidebarSearch;
   exports.Toasts = Toasts;

--- a/static/jscn/contstat.js
+++ b/static/jscn/contstat.js
@@ -94,15 +94,28 @@ async function initiate_dom_placeholder_creation (contiden) {
                 $("#contntfd").modal("show");
             } else {
                 let scpuqant = data["stats"]["cpu_stats"]["online_cpus"];
-                for (let indx = 0; indx < scpuqant; indx++) {
-                    $("#scpuperu").append(
-                        `
-                        <tr>
-                            <td class="pl-2 font-weight-bold">CPU #${indx}</td>
-                            <td class="pl-2 monotext" id="scpu-${indx}">${data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"][indx]}</td>
-                        </tr>
-                        `
-                    );
+                if (typeof(data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"]) !== "undefined") {
+                    for (let indx = 0; indx < scpuqant; indx++) {
+                        $("#scpuperu").append(
+                            `
+                            <tr>
+                                <td class="pl-2 font-weight-bold">CPU #${indx}</td>
+                                <td class="pl-2 monotext" id="scpu-${indx}">${data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"][indx]}</td>
+                            </tr>
+                            `
+                        );
+                    }
+                } else {
+                    for (let indx = 0; indx < scpuqant; indx++) {
+                        $("#scpuperu").append(
+                            `
+                            <tr>
+                                <td class="pl-2 font-weight-bold">CPU #${indx}</td>
+                                <td class="pl-2 monotext" id="scpu-${indx}">UNAVAILABLE</td>
+                            </tr>
+                            `
+                        );
+                    }
                 }
                 document.getElementById("scputotu").innerText = data["stats"]["cpu_stats"]["cpu_usage"]["total_usage"];
                 document.getElementById("scpukmus").innerText = data["stats"]["cpu_stats"]["cpu_usage"]["usage_in_kernelmode"];
@@ -113,15 +126,28 @@ async function initiate_dom_placeholder_creation (contiden) {
                 document.getElementById("scputhtp").innerText = data["stats"]["cpu_stats"]["throttling_data"]["throttled_periods"];
                 document.getElementById("scputhtm").innerText = data["stats"]["cpu_stats"]["throttling_data"]["throttled_time"];
                 let pcpuqant = data["stats"]["cpu_stats"]["online_cpus"];
-                for (let indx = 0; indx < pcpuqant; indx++) {
-                    $("#pcpuperu").append(
-                        `
-                        <tr>
-                            <td class="pl-2 font-weight-bold">CPU #${indx}</td>
-                            <td class="pl-2 monotext" id="pcpu-${indx}">${data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"][indx]}</td>
-                        </tr>
-                        `
-                    );
+                if (typeof(data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"]) !== "undefined") {
+                    for (let indx = 0; indx < pcpuqant; indx++) {
+                        $("#pcpuperu").append(
+                            `
+                            <tr>
+                                <td class="pl-2 font-weight-bold">CPU #${indx}</td>
+                                <td class="pl-2 monotext" id="pcpu-${indx}">${data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"][indx]}</td>
+                            </tr>
+                            `
+                        );
+                    }
+                } else {
+                    for (let indx = 0; indx < pcpuqant; indx++) {
+                        $("#pcpuperu").append(
+                            `
+                            <tr>
+                                <td class="pl-2 font-weight-bold">CPU #${indx}</td>
+                                <td class="pl-2 monotext" id="pcpu-${indx}">UNAVAILABLE</td>
+                            </tr>
+                            `
+                        );
+                    }
                 }
                 document.getElementById("pcputotu").innerText = data["stats"]["precpu_stats"]["cpu_usage"]["total_usage"];
                 document.getElementById("pcpukmus").innerText = data["stats"]["precpu_stats"]["cpu_usage"]["usage_in_kernelmode"];
@@ -220,8 +246,10 @@ async function refresh_container_stats_periodically (contiden, rfrstime, physgra
                     $("#contntfd").modal("show");
                 } else {
                     let scpuqant = data["stats"]["cpu_stats"]["online_cpus"];
-                    for (let indx = 0; indx < scpuqant; indx++) {
-                        document.getElementById("scpu-" + indx).innerText = data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"][indx];
+                    if (typeof(data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"]) !== "undefined") {
+                        for (let indx = 0; indx < scpuqant; indx++) {
+                            document.getElementById("scpu-" + indx).innerText = data["stats"]["precpu_stats"]["cpu_usage"]["percpu_usage"][indx];
+                        }
                     }
                     document.getElementById("scputotu").innerText = data["stats"]["cpu_stats"]["cpu_usage"]["total_usage"];
                     document.getElementById("scpukmus").innerText = data["stats"]["cpu_stats"]["cpu_usage"]["usage_in_kernelmode"];
@@ -232,8 +260,10 @@ async function refresh_container_stats_periodically (contiden, rfrstime, physgra
                     document.getElementById("scputhtp").innerText = data["stats"]["cpu_stats"]["throttling_data"]["throttled_periods"];
                     document.getElementById("scputhtm").innerText = data["stats"]["cpu_stats"]["throttling_data"]["throttled_time"];
                     let pcpuqant = data["stats"]["cpu_stats"]["online_cpus"];
-                    for (let indx = 0; indx < pcpuqant; indx++) {
-                        document.getElementById("pcpu-" + indx).innerText = data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"][indx];
+                    if (typeof(data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"]) !== "undefined") {
+                        for (let indx = 0; indx < pcpuqant; indx++) {
+                            document.getElementById("pcpu-" + indx).innerText = data["stats"]["cpu_stats"]["cpu_usage"]["percpu_usage"][indx];
+                        }
                     }
                     document.getElementById("pcputotu").innerText = data["stats"]["precpu_stats"]["cpu_usage"]["total_usage"];
                     document.getElementById("pcpukmus").innerText = data["stats"]["precpu_stats"]["cpu_usage"]["usage_in_kernelmode"];

--- a/static/jscn/mtrcdata.js
+++ b/static/jscn/mtrcdata.js
@@ -108,7 +108,7 @@ async function initiate_dom_placeholder_creation_and_population (mtrciden) {
                     let cppctext = (mtrcdata["cpuclock"][indx]["current"] * 100 / mtrcdata["cpuclock"][indx]["max"]).toPrecision(3).toString();
                     $("#cppclist").append(
                         `
-                        <div class="info-box bg-light mb-0">
+                        <div class="info-box mb-0">
                             <span class="info-box-icon"><i class="fas fa-microchip text-olive"></i></span>
                             <div class="info-box-content">
                                 <span class="info-box-text">CPU #${indx}</span>
@@ -161,7 +161,7 @@ async function initiate_dom_placeholder_creation_and_population (mtrciden) {
                     );
                     $("#cpsllist").append(
                         `
-                        <div class="info-box bg-light mb-0">
+                        <div class="info-box mb-0">
                             <span class="info-box-icon"><i class="fas fa-balance-scale text-olive"></i></span>
                             <div class="info-box-content">
                                 <span class="info-box-text">CPU #${indx}</span>

--- a/templates/conthtop.html
+++ b/templates/conthtop.html
@@ -81,7 +81,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
                 </div>
             </div>
         </div>

--- a/templates/continfo.html
+++ b/templates/continfo.html
@@ -40,16 +40,16 @@
                     <div class="card-tools">
                         <ul class="nav nav-pills ml-auto">
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="open_container_console_attachment_modal('{{ contiden }}')"><i class="fas fa-terminal"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %} pt-1 pb-1" onclick="open_container_console_attachment_modal('{{ contiden }}')"><i class="fas fa-terminal"></i></a>
                             </li>
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/contstat/{{ contiden }}'"><i class="fas fa-tachometer-alt"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %} pt-1 pb-1" onclick="document.location.href='/contstat/{{ contiden }}'"><i class="fas fa-tachometer-alt"></i></a>
                             </li>
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/contlogs/{{ contiden }}'"><i class="fas fa-file-alt"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %} pt-1 pb-1" onclick="document.location.href='/contlogs/{{ contiden }}'"><i class="fas fa-file-alt"></i></a>
                             </li>
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/conthtop/{{ contiden }}'"><i class="fas fa-chart-line"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %} pt-1 pb-1" onclick="document.location.href='/conthtop/{{ contiden }}'"><i class="fas fa-chart-line"></i></a>
                             </li>
                         </ul>
                     </div>
@@ -135,6 +135,10 @@
                     </table>
                 </div>
             </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6 col-sm-12 col-12">
             <div class="card">
                 <div class="card-header bg-olive pl-2">
                     <h3 class="card-title font-weight-bold">Masked paths</h3>
@@ -151,6 +155,8 @@
                     </table>
                 </div>
             </div>
+        </div>
+        <div class="col-md-6 col-sm-12 col-12">
             <div class="card">
                 <div class="card-header bg-olive pl-2">
                     <h3 class="card-title font-weight-bold">Readonly paths</h3>
@@ -185,7 +191,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
                 </div>
             </div>
         </div>
@@ -219,9 +225,9 @@
                     </div>
                 </div>
                 <div class="modal-footer justify-content-between pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal">Close</button>
                     <div class="float-right">
-                        <button type="button" class="btn btn-sm btn-light" onclick="initiate_container_attachment();" data-dismiss="modal">Start</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" onclick="initiate_container_attachment();" data-dismiss="modal">Start</button>
                     </div>
                 </div>
             </div>

--- a/templates/contlist.html
+++ b/templates/contlist.html
@@ -63,9 +63,9 @@
                     </div>
                 </div>
                 <div class="modal-footer justify-content-between pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal">Close</button>
                     <div class="float-right">
-                        <button type="button" class="btn btn-sm btn-light" onclick="initiate_container_attachment();" data-dismiss="modal">Start</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" onclick="initiate_container_attachment();" data-dismiss="modal">Start</button>
                     </div>
                 </div>
             </div>

--- a/templates/contlogs.html
+++ b/templates/contlogs.html
@@ -76,7 +76,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
                 </div>
             </div>
         </div>

--- a/templates/contstat.html
+++ b/templates/contstat.html
@@ -335,7 +335,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-teal">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/contlist/'">Return to containers listing</button>
                 </div>
             </div>
         </div>

--- a/templates/frameset.html
+++ b/templates/frameset.html
@@ -43,7 +43,7 @@
     </style>
     <body class="hold-transition sidebar-mini {% if darkmode == 1 %} dark-mode {% else %} light-mode {% endif %} text-sm" onload="{% block onldscpt %}{% endblock %}" style="">
         <div class="wrapper">
-            <nav class="main-header navbar navbar-expand {% if darkmode == 1 %} navbar-dark {% else %} navbar-light {% endif %} bg-light elevation-1">
+            <nav class="main-header navbar navbar-expand {% if darkmode == 1 %} navbar-dark {% else %} navbar-light {% endif %} elevation-1">
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link" data-widget="pushmenu" role="button"><i class="fas fa-bars"></i></a>
@@ -65,7 +65,7 @@
                 </ul>
             </nav>
             <aside class="main-sidebar {% if darkmode == 1 %} sidebar-dark-olive {% else %} sidebar-light-olive {% endif %} elevation-1">
-                <a class="brand-link {% if darkmode == 1 %} navbar-dark {% else %} navbar-light {% endif %} bg-light elevation-1">
+                <a class="brand-link {% if darkmode == 1 %} navbar-dark {% else %} navbar-light {% endif %} elevation-1">
                     <img src="{{ url_for("static", filename="imgs/mainicon.svg") }}" class="brand-image {% if darkmode == 1 %} dark-svgs {% else %} lite-svgs {% endif %}" style="opacity: .8">
                     <span class="brand-text font-weight-heavy">
                         SuperVisor
@@ -159,7 +159,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/svlogout/'">Return to login screen</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/svlogout/'">Return to login screen</button>
                     </div>
                 </div>
             </div>
@@ -178,7 +178,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/svlogout/'">Return to login screen</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/svlogout/'">Return to login screen</button>
                     </div>
                 </div>
             </div>
@@ -217,7 +217,7 @@
                         </div>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" data-dismiss="modal">Close</button>
                     </div>
                 </div>
             </div>
@@ -236,9 +236,9 @@
                         </p>
                     </div>
                     <div class="modal-footer justify-content-between pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Return</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" data-dismiss="modal">Return</button>
                         <div class="float-right">
-                            <button type="button" class="btn btn-sm btn-light" onclick="document.location.href='/svlogout/';" data-dismiss="modal">Logout</button>
+                            <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href='/svlogout/';" data-dismiss="modal">Logout</button>
                         </div>
                     </div>
                 </div>

--- a/templates/imejinfo.html
+++ b/templates/imejinfo.html
@@ -39,7 +39,7 @@
                     <div class="card-tools">
                         <ul class="nav nav-pills ml-auto">
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/imejrevs/{{ imejiden }}'" type="button"><i class="fas fa-clock"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pt-1 pb-1" onclick="document.location.href='/imejrevs/{{ imejiden }}'" type="button"><i class="fas fa-clock"></i></a>
                             </li>
                         </ul>
                     </div>
@@ -217,7 +217,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/imejlist/'">Return to images listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" onclick="document.location.href = '/imejlist/'">Return to images listing</button>
                 </div>
             </div>
         </div>

--- a/templates/imejrevs.html
+++ b/templates/imejrevs.html
@@ -51,7 +51,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/imejlist/'">Return to images listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/imejlist/'">Return to images listing</button>
                 </div>
             </div>
         </div>

--- a/templates/logepage.html
+++ b/templates/logepage.html
@@ -98,7 +98,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" data-dismiss="modal">Close</button>
                     </div>
                 </div>
             </div>

--- a/templates/mtrcdata.html
+++ b/templates/mtrcdata.html
@@ -336,7 +336,7 @@
                     <h3 class="card-title font-weight-bold" id="snbthead">Battery</h3>
                 </div>
                 <div class="card-body table-responsive p-0">
-                    <div class="info-box bg-light mb-0">
+                    <div class="info-box mb-0">
                         <span class="info-box-icon"><i class="fas fa-car-battery text-olive"></i></span>
                         <div class="info-box-content">
                             <span class="info-box-text">Remaining</span>
@@ -375,7 +375,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/mtrclist/'">Return to metric listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/mtrclist/'">Return to metric listing</button>
                 </div>
             </div>
         </div>

--- a/templates/ntwkinfo.html
+++ b/templates/ntwkinfo.html
@@ -37,7 +37,7 @@
                 <span class="info-box-icon bg-olive"><i class="fas fa-info-circle"></i></span>
                 <div class="info-box-content ellipsis">
                     <span class="info-box-text">Information</span>
-                    <span class="info-box-number h2 mb-0 condqant font-weight-normal">Preliminary</span>
+                    <span class="info-box-number h2 mt-0 mb-0 condqant font-weight-normal">Preliminary</span>
                 </div>
             </div>
         </div>
@@ -103,7 +103,7 @@
                 <span class="info-box-icon bg-olive"><i class="fas fa-wrench"></i></span>
                 <div class="info-box-content ellipsis">
                     <span class="info-box-text">Additional</span>
-                    <span class="info-box-number h2 mb-0 condqant font-weight-normal">Options</span>
+                    <span class="info-box-number h2 mt-0 mb-0 condqant font-weight-normal">Options</span>
                 </div>
             </div>
         </div>
@@ -133,7 +133,7 @@
                 <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
                 <div class="info-box-content ellipsis">
                     <span class="info-box-text">Active</span>
-                    <span class="info-box-number h2 mb-0 condqant font-weight-normal">Containers</span>
+                    <span class="info-box-number h2 mt-0 mb-0 condqant font-weight-normal">Containers</span>
                 </div>
             </div>
         </div>
@@ -149,7 +149,7 @@
                     <h3 class="modal-title condqant font-weight-bold">Network absent</h3>
                 </div>
                 <div class="modal-body pt-1 pb-1 pl-2 pr-2">
-                    <p class="text-justify mt-0 mb-0">
+                    <p class="text-justify mb-0">
                         The network identity provided does not match any from the list of existing networks on the
                         station and hence, the information pertaining to that network could not be displayed. Please
                         check your inputs for network identity and attempt again.

--- a/templates/ntwkinfo.html
+++ b/templates/ntwkinfo.html
@@ -100,19 +100,6 @@
     <div class="row">
         <div class="col-md-4 col-sm-12 col-12">
             <div class="info-box">
-                <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
-                <div class="info-box-content ellipsis">
-                    <span class="info-box-text">Active</span>
-                    <span class="info-box-number h2 mb-0 condqant font-weight-normal">Containers</span>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-8 col-sm-12 col-12" id="ntcnlist">
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4 col-sm-12 col-12">
-            <div class="info-box">
                 <span class="info-box-icon bg-olive"><i class="fas fa-wrench"></i></span>
                 <div class="info-box-content ellipsis">
                     <span class="info-box-text">Additional</span>
@@ -140,6 +127,19 @@
             </div>
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-4 col-sm-12 col-12">
+            <div class="info-box">
+                <span class="info-box-icon bg-olive"><i class="fas fa-box-open"></i></span>
+                <div class="info-box-content ellipsis">
+                    <span class="info-box-text">Active</span>
+                    <span class="info-box-number h2 mb-0 condqant font-weight-normal">Containers</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8 col-sm-12 col-12" id="ntcnlist">
+        </div>
+    </div>
 {% endblock %}
 {% block extramod %}
     <div class="modal fade" tabindex="-1" data-backdrop="static" role="dialog" id="ntwkntfd">
@@ -156,7 +156,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/ntwklist/'">Return to networks listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/ntwklist/'">Return to networks listing</button>
                 </div>
             </div>
         </div>

--- a/templates/proclist.html
+++ b/templates/proclist.html
@@ -74,7 +74,7 @@
                 </div>
                 <div class="modal-body pt-1 pb-1 pl-2 pr-2">
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">Preliminaries</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -113,7 +113,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">UIDs</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -136,7 +136,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">GIDs</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -159,7 +159,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">Context switches</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -178,7 +178,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">CPU times</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -209,7 +209,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <div class="card-header bg-light pl-2">
+                        <div class="card-header {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pl-2">
                             <h3 class="card-title font-weight-bold text-olive">Memory info</h3>
                         </div>
                         <div class="card-body table-responsive p-0">
@@ -249,12 +249,12 @@
                     </div>
                 </div>
                 <div class="modal-footer justify-content-between pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal">Close</button>
                     <div class="float-right">
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal" id="termbutn"><i class="fas fa-trash"></i></button>
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal" id="killbutn"><i class="fas fa-times"></i></button>
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal" id="contbutn"><i class="fas fa-play"></i></button>
-                        <button type="button" class="btn btn-sm btn-light" data-dismiss="modal" id="hangbutn"><i class="fas fa-pause"></i></button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal" id="termbutn"><i class="fas fa-trash"></i></button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal" id="killbutn"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal" id="contbutn"><i class="fas fa-play"></i></button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} {% endif %}" data-dismiss="modal" id="hangbutn"><i class="fas fa-pause"></i></button>
                     </div>
                 </div>
             </div>

--- a/templates/systdata.html
+++ b/templates/systdata.html
@@ -58,10 +58,10 @@
                     <div class="card-tools">
                         <ul class="nav nav-pills ml-auto">
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/proclist/'" type="button"><i class="fas fa-hashtag"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pt-1 pb-1" onclick="document.location.href='/proclist/'" type="button"><i class="fas fa-hashtag"></i></a>
                             </li>
                             <li class="nav-item ml-1 mr-1">
-                                <a class="nav-link text-olive bg-light pt-1 pb-1" onclick="document.location.href='/termpage/0000000000000000000000000000000000000000000000000000000000000000'" type="button"><i class="fas fa-terminal"></i></a>
+                                <a class="nav-link text-olive {% if darkmode == 1 %} bg-dark {% else %} bg-light {% endif %} pt-1 pb-1" onclick="document.location.href='/termpage/0000000000000000000000000000000000000000000000000000000000000000'" type="button"><i class="fas fa-terminal"></i></a>
                             </li>
                         </ul>
                     </div>

--- a/templates/termpage.html
+++ b/templates/termpage.html
@@ -99,7 +99,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light genrfont" onclick="document.location.href = '/'">Return to login screen</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} genrfont" onclick="document.location.href = '/'">Return to login screen</button>
                     </div>
                 </div>
             </div>
@@ -118,7 +118,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light genrfont" onclick="document.location.href = '/'">Return to login screen</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} genrfont" onclick="document.location.href = '/'">Return to login screen</button>
                     </div>
                 </div>
             </div>
@@ -137,7 +137,7 @@
                         </p>
                     </div>
                     <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                        <button type="button" class="btn btn-sm btn-light genrfont" onclick="window.history.back();">Back</button>
+                        <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %} genrfont" onclick="window.history.back();">Back</button>
                     </div>
                 </div>
             </div>

--- a/templates/volminfo.html
+++ b/templates/volminfo.html
@@ -88,7 +88,7 @@
                     </p>
                 </div>
                 <div class="modal-footer pt-1 pb-1 pl-2 pr-2 bg-olive">
-                    <button type="button" class="btn btn-sm btn-light" onclick="document.location.href = '/volmlist/'">Return to volumes listing</button>
+                    <button type="button" class="btn btn-sm {% if darkmode == 1 %} btn-dark {% else %} btn-light {% endif %}" onclick="document.location.href = '/volmlist/'">Return to volumes listing</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Updates the AdminLTE CSS framework from v3.1.0-rc to v3.1.0 actual release. The dark mode broke as a consequence and was promptly fixed with https://github.com/t0xic0der/supervisor-frontend-service/commit/90b6aad4ce6584ff15e441a73222e6da5b8c9066. The per-CPU usage statistics for containers was fixed then with https://github.com/t0xic0der/supervisor-frontend-service/commit/f74ce084ac73b690c288726451e91ffa02c4e63b. 