### PR TITLE
Added MANIFEST.in to recursively include template and static files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include src/svfrontend/templates *
+recursive-include src/svfrontend/static *


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

The previously built RPMs were broken as the static and template files were not included in the distribution, which is now fixed with the inclusion of a `MANIFEST.in` file.